### PR TITLE
fix(auth): persist user login state after page refresh

### DIFF
--- a/frontend/src/components/modules/authProvider.jsx
+++ b/frontend/src/components/modules/authProvider.jsx
@@ -1,9 +1,20 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Context } from './context'
 
 export const AuthProvider = ({ children }) => {
-  const [userLogin, setUserLogin] = useState({})
+  const [userLogin, setUserLogin] = useState(null)
   const [isLoggedIn, setIsLoggedIn] = useState(false)
+
+  // Al primo render recupera user e token da localStorage
+  useEffect(() => {
+    const storedUser = localStorage.getItem("user")
+    const storedToken = localStorage.getItem("token")
+
+    if (storedUser && storedToken) {
+      setUserLogin(JSON.parse(storedUser))
+      setIsLoggedIn(true)
+    }
+  }, [])
 
   return (
     <Context.Provider
@@ -14,7 +25,7 @@ export const AuthProvider = ({ children }) => {
         setIsLoggedIn,
       }}
     >
-      { children }
+      {children}
     </Context.Provider>
   )
 }

--- a/frontend/src/pages/auth/signIn.jsx
+++ b/frontend/src/pages/auth/signIn.jsx
@@ -10,7 +10,6 @@ import axios from "@config/axios.js";
 import MetaData from "@pages/noPage/metaData";
 
 export default function SignIn() {
-	const API_URL = import.meta.env.VITE_URL_BACKEND || "http://localhost:5001";
 	let navigate = useNavigate();
 
 	const loginSchema = yup


### PR DESCRIPTION
**Description**

This PR fixes the issue where the user login state was lost after refreshing the page.
Previously, the authentication context (AuthProvider) did not restore values from localStorage, causing users to appear logged out even though valid session data was stored.

Changes Introduced

- Added initialization logic in AuthProvider to load userLogin and isLoggedIn from localStorage.
- Ensured isLoggedIn remains true if a valid token/user exists in storage.
- Improved consistency of authentication flow across refreshes.

Issue Fixed

- Testing Steps
- Login with valid credentials.
- Refresh the page.

Verify that the user remains logged in and context values persist.