### PR TITLE
Remove /api prefix from backend routes

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -49,14 +49,14 @@ app.use(express.json())
 
 const port = process.env.PORT || 5000
 
-app.use('/api/test', routeGetStart)
-app.use('/api/auth', routeAuth)
-app.use('/api/users', authenticateUser, routeUsers)
-app.use('/api/earthquakes', routeEarthquakes)
-// app.use('/api/station', routeStations)
-// app.use('/api/geospatial', routeGeospatial)
-// app.use('/api/statistics', routeStats)
-// app.use('/api/', routeDemo)
+app.use('/test', routeGetStart)
+app.use('/auth', routeAuth)
+app.use('/users', authenticateUser, routeUsers)
+app.use('/earthquakes', routeEarthquakes)
+// app.use('/station', routeStations)
+// app.use('/geospatial', routeGeospatial)
+// app.use('/statistics', routeStats)
+// app.use('/demo', routeDemo)
 
 const startServer = async () => {
   try {


### PR DESCRIPTION
**Description:**
This PR updates all backend routes to remove the /api prefix. Since the backend is now served under the official subdomain api.terraquakeapi.com, the prefix is no longer needed.

Changes:

- Refactored all route definitions to remove /api
- Updated any internal calls to reflect the new endpoints
- Adjusted documentation and examples to match the new URLs

**Example:**

> 
> Before: /api/test
> After: /test

**Expected Behavior:**
All backend routes are accessible directly under the subdomain without the /api prefix. Frontend requests and external integrations should use the updated URLs.

**Notes:**

Ensure frontend and any API consumers are updated to the new route structure.
SSL and DNS configuration for api.terraquakeapi.com should be properly set.