### PR TITLE
Update API docs for recent earthquakes endpoint

### DIFF
--- a/backend/src/controllers/earthquakesControllers.js
+++ b/backend/src/controllers/earthquakesControllers.js
@@ -32,13 +32,16 @@ const fetchINGV = async (url) => {
 export const getEarthquakesByRecent = async (req, res) => {
   try {
     const urlINGV = process.env.URL_INGV
-    const limit = getPositiveInt(req.query, 'limit')
+    const limit = getPositiveInt(req.query, 'limit', { def: 50 })
 
     if (limit === null) {
-      return handleHttpError(res, 'The limit parameter must be a positive integer greater than 0. Example: ?limit=10', 400)
+      return handleHttpError(res, 'The limit parameter must be a positive integer greater than 0. Example: ?limit=50', 400)
     }
 
-    let url = `${urlINGV}?orderby=time&format=geojson`
+    const now = new Date().toISOString().split('T')[0]
+    const startOfYear = new Date(new Date().getFullYear(), 0, 1).toISOString().split('T')[0]
+
+    let url = `${urlINGV}?orderby=time&starttime=${startOfYear}&endtime=${now}&format=geojson`
     if (limit) url += `&limit=${limit}`
 
     const data = await fetchINGV(url)

--- a/frontend/src/components/apiDocs/apiDocsEarthquakes.jsx
+++ b/frontend/src/components/apiDocs/apiDocsEarthquakes.jsx
@@ -12,7 +12,8 @@ export default function ApiDocsEarthquakes() {
 	const endpoints = [
 		{
 			title: "recent",
-			description: `This endpoint retrieves all seismic events that occurred today from the TerraQuake API, based on UTC time. It provides users with real-time insight into ongoing seismic activity for the current day. The response includes detailed information such as magnitude, location, depth, time, and unique event ID.
+			description: `This endpoint retrieves all recent seismic events from the beginning of the year until today via the TerraQuake API sorted from the most recent to the least recent. It provides users with insight into ongoing seismic activity for the current year. The response includes details such as magnitude, location, depth, time, and unique event ID.
+
       
         Query Parameters:
           


### PR DESCRIPTION
**Description:**
This PR updates the documentation for the getEarthquakesByRecent endpoint in apiDocsEarthquakes.jsx.
Changes include:

- Clarifying that events are retrieved from the beginning of the year until today.
- Adding that events are sorted from most recent to least recent.
- Specifying that the response includes magnitude, location, depth, time, and unique event ID.