### PR TITLE
feat: add rate limiting middleware and update API routes to include versioning

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,6 +14,7 @@
         "dotenv": "17.0.1",
         "express": "4.21.2",
         "express-list-endpoints": "7.1.1",
+        "express-rate-limit": "^8.1.0",
         "express-validator": "7.2.1",
         "express-validators": "1.0.4",
         "haversine-distance": "1.2.4",
@@ -2007,6 +2008,24 @@
         "node": ">=18"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.1.0.tgz",
+      "integrity": "sha512-4nLnATuKupnmwqiJc27b4dCFmB/T60ExgmtDD7waf4LdrbJ8CPZzZRHYErDYNhoz+ql8fUdYwM/opf90PoPAQA==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express-validator": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.2.1.tgz",
@@ -2630,6 +2649,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,6 +19,7 @@
     "dotenv": "17.0.1",
     "express": "4.21.2",
     "express-list-endpoints": "7.1.1",
+    "express-rate-limit": "8.1.0",
     "express-validator": "7.2.1",
     "express-validators": "1.0.4",
     "haversine-distance": "1.2.4",

--- a/backend/src/middleware/rateLimiter.js
+++ b/backend/src/middleware/rateLimiter.js
@@ -1,0 +1,15 @@
+import rateLimit from 'express-rate-limit'
+
+// NOTE: Generic configuration for APIs
+export const apiLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max requests per IP
+  message: { message: 'Too many requests, please try again later.' }
+})
+
+// NOTE: Dedicated configuration only for authentication endpoints
+export const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 10, // stricter limit for login to prevent brute force
+  message: { message: 'Too many login attempts, please try again later.' }
+})

--- a/frontend/src/components/apiDocs/apiDocsEarthquakes.jsx
+++ b/frontend/src/components/apiDocs/apiDocsEarthquakes.jsx
@@ -20,7 +20,7 @@ This endpoint retrieves all recent seismic events from the beginning of the year
           
       - limit: (Optional) The number of earthquake events to return. Defaults to 50 if not specified.`,
 			query: "?limit=50",
-			example: "/earthquakes/recent?limit=50",
+			example: "/v1/earthquakes/recent?limit=50",
 			method: "GET"
 		},
 		{
@@ -32,7 +32,7 @@ This endpoint retrieves all seismic events that occurred today (from 00:00 UTC t
         
       - limit: (Optional) The number of earthquake events to return. Default is 50 if not provided.`,
       query: '?limit=50',
-      example: '/earthquakes/today?limit=50',
+      example: '/v1/earthquakes/today?limit=50',
       method: 'GET',
     },
     {
@@ -45,7 +45,7 @@ It allows users to monitor and analyze recent seismic activity over the past wee
         
       - limit: (Optional) The number of earthquake events to return. Default is 50 if not specified.`,
       query: '?limit=50',
-      example: '/earthquakes/last-week?limit=50',
+      example: '/v1/earthquakes/last-week?limit=50',
       method: 'GET',
     },
     {
@@ -60,7 +60,7 @@ It allows users to explore historical earthquake data for a given period. The re
       - month: (Required) The target month in numeric format (01 to 12).
       - limit: (Optional) The number of events to return. Default is 50 if not specified.`,
       query: '?year=2025&month=03&limit=50',
-      example: '/earthquakes/month?year=2025&month=03&limit=50',
+      example: '/v1/earthquakes/month?year=2025&month=03&limit=50',
       method: 'GET',
     },
     {
@@ -78,7 +78,7 @@ This endpoint fetches seismic events close to a given geographical location, def
 
 The response includes detailed information for each event such as magnitude, coordinates, depth, and time of occurrence.`,
       query: '?latitude=40.835459&longitude=14.117358&radius=50&limit=50',
-      example: '/earthquakes/location?latitude=40.835459&longitude=14.117358&radius=50&limit=50',
+      example: '/v1/earthquakes/location?latitude=40.835459&longitude=14.117358&radius=50&limit=50',
       method: 'GET',
     },
     {
@@ -94,7 +94,7 @@ for localized seismic analysis. The response includes key data such as magnitude
       - region: (Required) The name of the Italian region to filter by (e.g., Campania, Sicilia, Lazio). Case-insensitive.
       - limit: (Optional) The number of events to return. Defaults to 50 if not specified.`,
       query: '?region=Campania&limit=50',
-      example: '/earthquakes/region?region=Campania&limit=50',
+      example: '/v1/earthquakes/region?region=Campania&limit=50',
       method: 'GET',
     },
     {
@@ -109,7 +109,7 @@ It allows users to analyze earthquakes based on their depth, which can help asse
       - depth: (Required) The focal depth of the earthquakes in kilometers (e.g., 10).
       - limit: (Optional) The number of events to return. Default is 10 if not specified.`,
       query: '?depth=10&limit=50',
-      example: '/earthquakes/depth?depth=10&limit=50',
+      example: '/v1/earthquakes/depth?depth=10&limit=50',
       method: 'GET',
     },
     {
@@ -125,7 +125,7 @@ It allows users to query historical earthquake data over any desired period, mak
       - limit: (Optional) The number of earthquake events to return. Default is 50 if not specified.`,
       query: '?startdate=2025-01-01&enddate=2025-03-30&limit=50',
       example:
-        '/earthquakes/range-time?startdate=2025-01-01&enddate=2025-03-30&limit=50',
+        '/v1/earthquakes/range-time?startdate=2025-01-01&enddate=2025-03-30&limit=50',
       method: 'GET',
     },
     {
@@ -153,7 +153,7 @@ It allows users to access detailed information about a single earthquake event, 
       
       - eventId: (Required) The unique identifier of the earthquake event to retrieve.`,
 			query: "?eventId=44085192",
-			example: "/earthquakes/eventId?eventId=44085192",
+			example: "/v1/earthquakes/eventId?eventId=44085192",
 			method: "GET"
 		}
 	];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "TerraQuakeApi",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
This PR introduces rate limiting middleware for the API to improve security and prevent abuse, and updates all API routes to include versioning (`/api/v1`) for better organization and maintainability.

**Changes included:**

- Added `apiLimiter` for general API endpoints (max 100 requests per 15 minutes per IP)
- Added `authLimiter` for authentication endpoints (max 10 requests per 15 minutes per IP) to prevent brute force attacks
- Updated all API routes to include `/api/v1` prefix:
  - `/test` → `/v1/test`
  - `/earthquakes` → `/v1/earthquakes`
  - `/station` → `/v1/station`
  - `/geospatial` → `/v1/geospatial`
  - `/statistics` → `/v1/statistics`
  - `/demo` → `/v1/demo`
  
- Added global error handler to catch unhandled errors and return consistent JSON responses
- Updated server logs to reflect new versioned routes

This improves the API's robustness, security, and prepares the application for external usage with Bearer token authentication in future.


