### PR TITLE
fix: load rate limit configuration from environment variables

### DIFF
--- a/backend/src/middleware/rateLimiter.js
+++ b/backend/src/middleware/rateLimiter.js
@@ -1,7 +1,13 @@
 import rateLimit from 'express-rate-limit'
+import dotenv from 'dotenv'
 
-const WINDOW_MS = 1000
-const LIMIT = 100
+dotenv.config()
+
+// NOTE: Load rate limit configuration from environment variables
+// WINDOW_MS = time window in milliseconds (e.g., 1000 = 1 second)
+// RATE_LIMIT = maximum number of requests allowed per IP in that time window
+const WINDOW_MS = Number(process.env.WINDOW_MS) || 1000
+const LIMIT = Number(process.env.RATE_LIMIT) || 100
 
 // Fixed window approach using HashMap { ip: { count: number, windowStart: number } }
 const buckets = new Map()


### PR DESCRIPTION
Updated rateLimiter.js to read WINDOW_MS and RATE_LIMIT from .env
instead of hardcoded values. This allows easy configuration of rate
limits without changing the source code, improving flexibility and
maintainability.