### PR TITLE
Fix password validation messages in signUp schema

### DIFF
--- a/frontend/src/pages/auth/signUp.jsx
+++ b/frontend/src/pages/auth/signUp.jsx
@@ -22,13 +22,12 @@ export default function SignUp() {
         .required('Email is required!'),
 
       password: yup
-        .string()
-        .required('Password is required !')
-        .min(8, 'Password must be at least 8 characters !')
-        .matches(/[A-Z]/, 'Must contain an uppercase letter !')
-        .matches(/\d/, 'Must contain a number !')
-        .matches(/[^A-Za-z0-9]/)
-        .withMessage('Password must contain at least one special character.'),
+      .string()
+      .required('Password is required!')
+      .min(8, 'Password must be at least 8 characters!')
+      .matches(/[A-Z]/, 'Must contain an uppercase letter!')
+      .matches(/\d/, 'Must contain a number!')
+      .matches(/[^A-Za-z0-9]/, 'Password must contain at least one special character!'),
 
       confirmPassword: yup
         .string()


### PR DESCRIPTION
This pull request fixes an issue in the SignUp component where Yup validation was throwing an error:

Uncaught TypeError: yup.string(...).required(...).min(...).matches(...).matches(...).matches(...).withMessage is not a function

The problem was caused by the incorrect use of .withMessage(), which is not part of Yup's API.  
The fix moves the error message directly into the .matches() calls as the second argument, in accordance with Yup's documentation.

Changes:
- Updated signUpSchema in SignUp.jsx to remove .withMessage().
- Added proper error messages directly to .matches() validators.
- Cleaned up schema formatting for clarity.

This fix ensures proper form validation and removes runtime errors in SignUp page.