### PR TITLE
This PR introduces Prometheus metrics collection for the TerraQuake API.

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -62,9 +62,6 @@ app.use(mongoSanitize())
 app.use(xss())
 app.use(hpp())
 
-// === METRICS MIDDLEWARE ===
-app.use(metricsMiddleware)
-
 // Body parser
 app.use(express.json({ limit: '10kb' })) // evita payload enormi
 app.use(express.urlencoded({ extended: true }))
@@ -78,6 +75,9 @@ const corsOptions = {
   credentials: true
 }
 app.use(cors(corsOptions))
+
+// === METRICS MIDDLEWARE ===
+app.use(metricsMiddleware)
 
 // === ROUTES ===
 // Solo /v1/earthquakes è pubblico

--- a/backend/src/controllers/earthquakesControllers.js
+++ b/backend/src/controllers/earthquakesControllers.js
@@ -1,4 +1,4 @@
-import { eventsProcessed, apiLatencyHistogram } from '../middleware/metrics.js'
+import { eventsProcessed } from '../middleware/metrics.js'
 
 import { regionBoundingBoxes } from '../config/regionBoundingBoxes.js'
 import handleHttpError from '../utils/handleHttpError.js'
@@ -56,8 +56,6 @@ const fetchINGV = async (url) => {
  * @param {import('express').Response} res - Express response object.
  */
 export const getEarthquakesByRecent = async (req, res) => {
-  const end = apiLatencyHistogram.startTimer() // start timer
-
   try {
     const urlINGV = process.env.URL_INGV
     const limit = getPositiveInt(req.query, 'limit', { def: 50 })
@@ -106,8 +104,6 @@ export const getEarthquakesByRecent = async (req, res) => {
       res,
       error.message.includes('HTTP error') ? error.message : undefined
     )
-  } finally {
-    end() // stop timer
   }
 }
 
@@ -119,8 +115,6 @@ export const getEarthquakesByRecent = async (req, res) => {
  * @param {import('express').Response} res
  */
 export const getEarthquakesByToday = async (req, res) => {
-  const end = apiLatencyHistogram.startTimer() // start timer
-
   try {
     const urlINGV = process.env.URL_INGV
     const limit = getPositiveInt(req.query, 'limit', { def: 50 })
@@ -166,8 +160,6 @@ export const getEarthquakesByToday = async (req, res) => {
       res,
       error.message.includes('HTTP error') ? error.message : undefined
     )
-  } finally {
-    end() // stop timer
   }
 }
 
@@ -179,8 +171,6 @@ export const getEarthquakesByToday = async (req, res) => {
  * @param {import('express').Response} res
  */
 export const getEarthquakesByLastWeek = async (req, res) => {
-  const end = apiLatencyHistogram.startTimer() // start timer
-
   try {
     const urlINGV = process.env.URL_INGV
     const limit = getPositiveInt(req.query, 'limit', { def: 50 })
@@ -234,8 +224,6 @@ export const getEarthquakesByLastWeek = async (req, res) => {
       res,
       error.message.includes('HTTP error') ? error.message : undefined
     )
-  } finally {
-    end() // stop timer
   }
 }
 
@@ -249,8 +237,6 @@ export const getEarthquakesByLastWeek = async (req, res) => {
  * @param {import('express').Response} res
  */
 export const getEarthquakesByMonth = async (req, res) => {
-  const end = apiLatencyHistogram.startTimer() // start timer
-
   try {
     const urlINGV = process.env.URL_INGV
     const { year, month } = req.query
@@ -310,8 +296,6 @@ export const getEarthquakesByMonth = async (req, res) => {
       res,
       error.message.includes('HTTP error') ? error.message : undefined
     )
-  } finally {
-    end() // stop timer
   }
 }
 
@@ -324,8 +308,6 @@ export const getEarthquakesByMonth = async (req, res) => {
  * @param {import('express').Response} res
  */
 export const getEarthquakesByRegion = async (req, res) => {
-  const end = apiLatencyHistogram.startTimer() // start timer
-
   try {
     const urlINGV = process.env.URL_INGV
     const { region } = req.query
@@ -382,8 +364,6 @@ export const getEarthquakesByRegion = async (req, res) => {
       res,
       error.message.includes('HTTP error') ? error.message : undefined
     )
-  } finally {
-    end() // stop timer
   }
 }
 
@@ -396,8 +376,6 @@ export const getEarthquakesByRegion = async (req, res) => {
  * @param {import('express').Response} res
  */
 export const getEarthquakesByDepth = async (req, res) => {
-  const end = apiLatencyHistogram.startTimer() // start timer
-
   try {
     const urlINGV = process.env.URL_INGV
     const { depth } = req.query
@@ -451,8 +429,6 @@ export const getEarthquakesByDepth = async (req, res) => {
   } catch (error) {
     console.error('Error in the earthquakes/depth controller:', error.message)
     handleHttpError(res, error.message.includes('HTTP error') ? error.message : undefined)
-  } finally {
-    end() // stop timer
   }
 }
 
@@ -466,8 +442,6 @@ export const getEarthquakesByDepth = async (req, res) => {
  * @param {import('express').Response} res
  */
 export const getEarthquakesByDateRange = async (req, res) => {
-  const end = apiLatencyHistogram.startTimer() // start timer
-
   try {
     const urlINGV = process.env.URL_INGV
     const { startdate, enddate } = req.query
@@ -532,8 +506,6 @@ export const getEarthquakesByDateRange = async (req, res) => {
       res,
       error.message.includes('HTTP error') ? error.message : undefined
     )
-  } finally {
-    end() // stop timer
   }
 }
 
@@ -546,8 +518,6 @@ export const getEarthquakesByDateRange = async (req, res) => {
  * @param {import('express').Response} res
  */
 export const getEarthquakesByMagnitude = async (req, res) => {
-  const end = apiLatencyHistogram.startTimer() // start timer
-
   try {
     const urlINGV = process.env.URL_INGV
     const { mag } = req.query
@@ -620,8 +590,6 @@ export const getEarthquakesByMagnitude = async (req, res) => {
       res,
       error.message.includes('HTTP error') ? error.message : undefined
     )
-  } finally {
-    end() // stop timer
   }
 }
 
@@ -634,8 +602,6 @@ export const getEarthquakesByMagnitude = async (req, res) => {
  * @param {import('express').Response} res
  */
 export const getEarthquakesById = async (req, res) => {
-  const end = apiLatencyHistogram.startTimer() // start timer
-
   try {
     const urlINGV = process.env.URL_INGV
     const { eventId } = req.query
@@ -680,8 +646,6 @@ export const getEarthquakesById = async (req, res) => {
       res,
       error.message.includes('HTTP error') ? error.message : undefined
     )
-  } finally {
-    end() // stop timer
   }
 }
 
@@ -696,8 +660,6 @@ export const getEarthquakesById = async (req, res) => {
  * @param {import('express').Response} res
  */
 export const getEarthquakesLocation = async (req, res) => {
-  const end = apiLatencyHistogram.startTimer() // start timer
-
   try {
     const urlINGV = process.env.URL_INGV
     const { latitude, longitude } = req.query
@@ -779,7 +741,5 @@ export const getEarthquakesLocation = async (req, res) => {
       res,
       error.message.includes('HTTP error') ? error.message : undefined
     )
-  } finally {
-    end() // stop timer
   }
 }

--- a/frontend/src/pages/about/about.jsx
+++ b/frontend/src/pages/about/about.jsx
@@ -107,10 +107,11 @@ export default function About() {
             description: 'Real-time earthquakes normalized and accessible',
           },
           {
-            value: `${(data.apiLatencyAvg || 0).toFixed(3)} s`,
+            value: `${data.apiLatencyAvgMs} ms`,
             label: 'API Latency',
-            description: 'Average response time across global regions',
+            description: 'Average API response time',
           },
+
           {
             value: `${Math.floor(data.uptime)} s`,
             label: 'Uptime',


### PR DESCRIPTION
Changes made:
- Updated `metricsControllers.js` to calculate API latency in milliseconds.
- Updated `/v1/metrics/json` endpoint to return `apiLatencyAvg` in ms.
- Enhanced `metricsMiddleware` to measure request latency more accurately.
- Added detailed comments in English for maintainability.
- Improved JSON metrics response structure with clearer units.

Metrics now include:
- Total events processed
- Average API latency in milliseconds
- API uptime (seconds)
- Memory usage (bytes)

This update improves performance monitoring and observability of the API.