### PR TITLE
Fix: reset displayed path on Clear Map click by using updated earthqu…

### DIFF
--- a/frontend/src/components/map/showInfo.jsx
+++ b/frontend/src/components/map/showInfo.jsx
@@ -50,8 +50,12 @@ export default function ShowInfo({ earthquakeData }) {
         )}
       </div>
       <p className='py-3'>
-        {urlBackend}
-        {earthquakeData?.meta?.path || 'no path available'}
+        View path:{' '}
+        <span className='text-gray-400 font-mono'>
+          {urlBackend && earthquakeData?.meta?.path
+            ? `${urlBackend}${earthquakeData.meta.path}`
+            : 'No path available'}
+        </span>
       </p>
     </section>
   );

--- a/frontend/src/components/map/viewMap.jsx
+++ b/frontend/src/components/map/viewMap.jsx
@@ -3,7 +3,7 @@
  * @author Koustubh Badshah
  */
 
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Map from 'ol/Map.js';
 import View from 'ol/View.js';
 import TileLayer from 'ol/layer/Tile.js';
@@ -17,9 +17,16 @@ import ShowProperties from './showProperties';
 import Legend from './legend';
 
 const ViewMap = ({ earthquakeData }) => {
+  const [currentEarthquakeData, setCurrentEarthquakeData] =
+    useState(earthquakeData);
+
   const mapRef = useRef(null);
   const mapInstance = useRef(null);
   const data = earthquakeData?.data;
+
+  useEffect(() => {
+    setCurrentEarthquakeData(earthquakeData);
+  }, [earthquakeData]);
 
   useEffect(() => {
     if (!mapRef.current) return;
@@ -64,7 +71,7 @@ const ViewMap = ({ earthquakeData }) => {
       </div>
 
       <div className='w-full max-w-6xl bg-white/5 border border-white/10 rounded-2xl p-4 shadow-xl'>
-        <ShowInfo earthquakeData={earthquakeData} />
+        <ShowInfo earthquakeData={currentEarthquakeData} />
         <ShowProperties mapInstance={mapInstance.current} />
         <div
           ref={mapRef}
@@ -76,7 +83,10 @@ const ViewMap = ({ earthquakeData }) => {
 
         <div className='flex flex-row justify-between items-center mt-4'>
           <button
-            onClick={() => addEarthquakeMarkers(mapInstance.current, ['clear'])}
+            onClick={() => {
+              addEarthquakeMarkers(mapInstance.current, ['clear']);
+              setCurrentEarthquakeData(null);
+            }}
             className='py-2 px-4 rounded-full bg-gradient-to-r from-pink-500 to-purple-600 text-white font-semibold hover:from-pink-600 hover:to-purple-700 transition-colors cursor-pointer'
           >
             Clear Map


### PR DESCRIPTION
This PR fixes an issue where the "Clear Map" button did not reset the displayed view path in the ShowInfo component.  

Changes:
- Added state `currentEarthquakeData` in ViewMap to track current earthquake data.
- Updated ShowInfo to use `currentEarthquakeData`.
- Clear Map button now sets `currentEarthquakeData` to null, clearing the path display.

