### PR TITLE
docs: add API authentication section

### DIFF
--- a/frontend/src/pages/docs/docs.jsx
+++ b/frontend/src/pages/docs/docs.jsx
@@ -18,13 +18,13 @@ export default function Docs() {
       />
       {/* SEO Stuff */}
 
-      <motion.section 
+      <motion.section
         className="relative z-0 w-full min-h-screen pt-24 pb-12 overflow-hidden"
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ duration: 0.8 }}
       >
-         {/* Background Gradient */}
+        {/* Background Gradient */}
         <div className="absolute inset-0 z-0">
           <div className="absolute top-0 left-0 w-80 h-80 bg-purple-500 rounded-full mix-blend-multiply filter blur-3xl opacity-30 animate-blob" />
           <div className="absolute bottom-10 right-10 w-96 h-96 bg-pink-500 rounded-full mix-blend-multiply filter blur-3xl opacity-30 animate-blob animation-delay-2000" />
@@ -44,11 +44,11 @@ export default function Docs() {
               <div className="h-0.5 w-1/3 md:w-1/4 mx-auto bg-gradient-to-r from-pink-500 via-purple-500 to-violet-500 my-2 rounded-full" />
             </h1>
             <p className="text-xl text-left text-white/70 max-w-7xl">
-             Learn how to use the TerraQuake API with guides, examples, and
-            reference documentation.
+              Learn how to use the TerraQuake API with guides, examples, and
+              reference documentation.
             </p>
           </motion.div>
-        
+
           {/* Introduction */}
           <section id='intro'>
             <h2 className='text-2xl font-bold mb-4'>Introduction</h2>
@@ -64,21 +64,42 @@ export default function Docs() {
           <section id='getting-started'>
             <h2 className='text-2xl font-bold mb-4'>Getting Started</h2>
             <p>Make your first request:</p>
-            <pre className='text-green-300 p-4 rounded-md overflow-x-auto mt-2'>
+            <pre className='text-green-300 p-4 rounded-md overflow-x-auto mt-2 bg-black/50'>
               {`curl -X GET "https://api.terraquakeapi.com/v1/earthquakes/recent?limit=10&page=1"`}
             </pre>
           </section>
 
-          {/* Authentication */}
+          {/* Authentication Section */}
           <section id='auth'>
             <h2 className='text-2xl font-bold mb-4'>Authentication</h2>
-            <p>
-              If authentication is required, include your API key in the header:
+            <div className="bg-gray-800/50 p-4 rounded-lg mb-6 border border-gray-700">
+              <h3 className="text-lg font-semibold mb-2 text-yellow-300">Current Status: No Authentication Required</h3>
+              <p className="text-gray-300">
+                <strong>For now, the API is completely open and does not require any authentication.</strong> You can make requests to all available endpoints without needing an API key or token.
+              </p>
+            </div>
+            <h3 className="text-xl font-bold mt-8 mb-3">Future Authentication Method</h3>
+            <p className="mb-4">
+              To ensure fair usage and security in the future, we will implement a system using <strong>Bearer Tokens</strong>. When this is active, you will need to include your unique token in the `Authorization` header of every request as shown below.
             </p>
-            <pre className='text-green-300 p-4 rounded-md overflow-x-auto mt-2'>
-              {`curl -H "Authorization: Bearer YOUR_API_KEY" \\
-"https://api.terraquakeapi.com/v1/earthquakes/recent"`}
+            <p>The process will be:</p>
+            <ul className="list-disc list-inside my-4 space-y-2">
+              <li>First, you will sign up for an account.</li>
+              <li>Then, you will generate an API token from your user dashboard.</li>
+              <li>Finally, you will use that token to authenticate your requests.</li>
+            </ul>
+            <h4 className='text-lg font-semibold mt-6 mb-2'>Example Authenticated Request</h4>
+            <p className="mb-2">
+              The header should be formatted as: <code className="bg-gray-700 text-green-300 px-2 py-1 rounded">Authorization: Bearer &lt;YOUR_API_TOKEN&gt;</code>
+            </p>
+
+            <pre className='text-green-300 p-4 rounded-md overflow-x-auto mt-2 bg-black/50'>
+              {`curl "https://api.terraquakeapi.com/v1/earthquakes/recent?limit=1" \\
+  -H "Authorization: Bearer <YOUR_API_TOKEN>"`}
             </pre>
+            <p className="mt-6 text-gray-400 italic">
+              Note: This authentication system is not yet active. This documentation will be updated when it is implemented.
+            </p>
           </section>
 
           {/* API Reference */}
@@ -178,12 +199,12 @@ export default function Docs() {
             </div>
 
             <h3 className='text-xl font-semibold mt-8'>Example Request</h3>
-            <pre className='text-green-300 p-4 rounded-md overflow-x-auto'>
+            <pre className='text-green-300 p-4 rounded-md overflow-x-auto mt-2 bg-black/50'>
               {`curl "https://api.terraquakeapi.com/v1/earthquakes/recent?limit=50&page=1"`}
             </pre>
 
             <h3 className='text-xl font-semibold mt-6'>Example Response</h3>
-            <pre className=' text-gray-100 p-4 rounded-md overflow-x-auto'>
+            <pre className='text-green-300 p-4 rounded-md overflow-x-auto mt-2 bg-black/50'>
               {`{
   "success": true,
   "code": 200,


### PR DESCRIPTION
Replaces the placeholder authentication content with a detailed section on the documentation page.

This new section clarifies that no authentication is currently required but explains the future plan for Bearer Token authentication, complete with usage examples.

Screenshots
<img width="1259" height="628" alt="image" src="https://github.com/user-attachments/assets/47aede25-0d16-46d6-9b08-e4a25d0c024b" />

Closes #51 

Also improving styling for this example component
<img width="744" height="638" alt="image" src="https://github.com/user-attachments/assets/02814f52-6c84-40f6-ae46-20cbf9234025" />
