### PR TITLE
refactor(css): centralize theme with custom properties

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,6 +1,20 @@
 @import url('https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,500;0,700;1,500;1,700&display=swap');
 @import "tailwindcss";
 
+:root {
+  --color-primary: #6b21a8;
+  --color-primary-hover: #8b5cf6;
+  --color-secondary: #0f0c29;
+  --color-border: #8b5cf6;
+  --color-text-primary: #ffffff;
+  --color-text-secondary: #e0e0e0;
+  --color-bg-body: #0f0c29;
+  --color-bg-light: #1a1733;
+  --scrollbar-width: 12px;
+  --radius-md: 6px;
+}
+
+/* These font classes do not need changes */
 .poppins-bold {
   font-family: "Poppins", sans-serif;
   font-weight: 700;
@@ -20,33 +34,41 @@
 }
 
 
+/* ================================================================ */
+/* 👇 2. REFACTOR EXISTING STYLES TO USE THE VARIABLES 👇 */
+/* ================================================================ */
 
-/* Tutta la scrollbar */
+/* Tutta la scrollbar (for Webkit browsers like Chrome, Safari) */
 ::-webkit-scrollbar {
-  width: 12px;
+  width: var(--scrollbar-width);
 }
 
 /* Sfondo della scrollbar */
 ::-webkit-scrollbar-track {
-  background: #0f0c29;
+  background: var(--color-secondary);
+  /* CHANGED */
 }
 
 /* Thumb (parte mobile) */
 ::-webkit-scrollbar-thumb {
-  background-color: #6b21a8;
-  border-radius: 6px;
+  background-color: var(--color-primary);
+  /* CHANGED */
+  border-radius: var(--radius-md);
+  /* CHANGED */
   border: 3px solid transparent;
   background-clip: content-box;
 }
 
 /* Al passaggio del mouse */
 ::-webkit-scrollbar-thumb:hover {
-  background-color: #8b5cf6;
+  background-color: var(--color-primary-hover);
+  /* CHANGED */
 }
 
 /* Per Firefox */
 html {
-  scrollbar-color: #6b21a8 #0f0c29; /* thumb / track */
+  scrollbar-color: var(--color-primary) var(--color-secondary);
+  /* CHANGED: thumb / track */
   scrollbar-width: thin;
 }
 
@@ -55,37 +77,52 @@ body {
   font-family: "Poppins", sans-serif;
   font-weight: 300;
   font-style: normal;
+  /* ADDED these lines to apply the global theme */
+  background-color: var(--color-bg-body);
+  color: var(--color-text-primary);
 }
 
 .custom-swal-popup {
-  border: #8b5cf6;
+  border-color: var(--color-border);
+  /* CHANGED */
+  /* Note: 'border' needs a style and width, e.g., 'border: 1px solid var(--color-border)'. 
+     I've used 'border-color' to be safe. */
 }
 
+
+/* These animation classes do not need changes */
 @keyframes dangle-bouncy {
-  0%, 100% {
+
+  0%,
+  100% {
     transform: rotate(0deg);
   }
+
   25% {
     transform: rotate(15deg);
   }
+
   50% {
     transform: rotate(-10deg);
   }
+
   75% {
     transform: rotate(5deg);
   }
 }
-
 
 .group:hover .dangle-on-hover {
   animation: dangle-bouncy 1.2s ease-in-out infinite;
 }
 
 @keyframes subtle-bounce {
-  0%, 100% {
+
+  0%,
+  100% {
     transform: translateY(-15%);
     animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
   }
+
   50% {
     transform: translateY(0);
     animation-timing-function: cubic-bezier(0, 0, 0.2, 1);


### PR DESCRIPTION
Introduces a `:root` configuration in index.css to define global CSS variables for colors, spacing, and border-radius.

Replaces hardcoded values in the body, scrollbar, and popup styles with the new variables. This improves maintainability, promotes consistency, and simplifies future design updates.

Closes #173