### PR TITLE
feat(auth): include additional optional user fields in Google OAuth

### DIFF
--- a/backend/src/config/passportConfig.js
+++ b/backend/src/config/passportConfig.js
@@ -28,6 +28,11 @@ passport.use(
             avatar: profile.photos?.[0]?.value || '',
             experience: '',
             student: 'No',
+            location: '',
+            website: '',
+            portfolio: '',
+            github: '',
+            bio: '',
             terms: true,
             role: ['user']
           })


### PR DESCRIPTION
### Summary
This PR updates the Google OAuth strategy to include additional optional
user fields: bio, website, portfolio, github, and location. These fields
are set as empty strings when a new user is created via Google login.

### Changes
- Updated `passport.js` GoogleStrategy to initialize new user with:
  - bio
  - website
  - portfolio
  - github
  - location

### Motivation
This allows the frontend to display and update these profile fields
later, ensuring a more complete user profile after Google OAuth login.

No breaking changes; existing users remain unaffected.
