### PR TITLE
feat: integrate INGV seismic stations API in backend

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -36,6 +36,7 @@
         "swagger-jsdoc": "6.2.8",
         "swagger-ui-express": "5.0.1",
         "ua-parser-js": "2.0.5",
+        "xml2js": "0.6.2",
         "xss-clean": "0.1.4"
       },
       "devDependencies": {
@@ -4914,6 +4915,12 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "license": "ISC"
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -6146,6 +6153,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/xss-clean": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -41,6 +41,7 @@
     "swagger-jsdoc": "6.2.8",
     "swagger-ui-express": "5.0.1",
     "ua-parser-js": "2.0.5",
+    "xml2js": "0.6.2",
     "xss-clean": "0.1.4"
   },
   "devDependencies": {

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -14,6 +14,7 @@ import routeUsers from './routes/usersRoutes.js'
 import routeContact from './routes/contactRoutes.js'
 import routeGetStart from './routes/testRoutes.js'
 import routeEarthquakes from './routes/earthquakesRoutes.js'
+import routeStation from './routes/stationsRoutes.js'
 import routeGitHub from './routes/githubAuthRoutes.js'
 import newsletterRoutes from './routes/newsletterRoutes.js'
 import dbConnect from './config/mongoConfig.js'
@@ -59,6 +60,7 @@ app.use(cors({
 
 // Public route: earthquakes data, accessible from any origin
 app.use('/v1/earthquakes', cors({ origin: '*' }), apiLimiter, routeEarthquakes)
+app.use('/v1/stations', cors({ origin: '*' }), apiLimiter, routeStation)
 
 // Protected routes
 app.use('/v1/test', apiLimiter, routeGetStart)

--- a/backend/src/controllers/seimiscStationsControllers.js
+++ b/backend/src/controllers/seimiscStationsControllers.js
@@ -1,0 +1,54 @@
+import { fetchINGVStations } from '../services/ingvStationService.js'
+import { getPositiveInt } from '../utils/httpQuery.js'
+
+/**
+ * Controller to fetch all seismic stations from INGV.
+ * Supports an optional "limit" query parameter to limit the number of stations returned.
+ *
+ * @param {Object} dependencies - Dependencies injected for response building and error handling
+ * @param {Function} dependencies.buildResponse - Utility to format API responses
+ * @param {Function} dependencies.handleHttpError - Utility to handle HTTP errors
+ * @returns {Function} Express handler function
+ */
+export const getAllStations = ({ buildResponse, handleHttpError }) => {
+  return async (req, res) => {
+    try {
+      // Parse and validate the "limit" query parameter (default: 50)
+      const limit = getPositiveInt(req.query, 'limit', { def: 50 })
+
+      if (limit === null) {
+        // If limit is invalid, return a 400 Bad Request with an explanatory message
+        return handleHttpError(
+          res,
+          'The limit parameter must be a positive integer greater than 0. Example: ?limit=50',
+          400
+        )
+      }
+
+      // Fetch all stations from the INGV API
+      const stations = await fetchINGVStations()
+
+      // Apply the limit to the list of stations
+      const limitedStations = stations.slice(0, limit)
+
+      // Return the response including the stations and pagination metadata
+      res.status(200).json({
+        ...buildResponse(req, 'List stations seismic INGV', limitedStations),
+        pagination: {
+          limit, // Number of stations requested
+          total: stations.length, // Total stations retrieved from INGV
+          hasMore: stations.length > limit // Whether more stations exist beyond the limit
+        }
+      })
+    } catch (error) {
+      // Log error to the server console
+      console.error('Error retrieving stations:', error.message)
+
+      // Handle unexpected errors gracefully
+      handleHttpError(
+        res,
+        error.message.includes('HTTP error') ? error.message : undefined
+      )
+    }
+  }
+}

--- a/backend/src/routes/stationsRoutes.js
+++ b/backend/src/routes/stationsRoutes.js
@@ -1,4 +1,7 @@
 import express from 'express'
+import { getAllStations } from '../controllers/seimiscStationsControllers.js'
+import { buildResponse } from '../utils/buildResponse.js'
+import handleHttpError from '../utils/handleHttpError.js'
 
 const router = express.Router()
 
@@ -6,7 +9,7 @@ const router = express.Router()
 
 // NOTE: List and details of active seismic stations
 // GET / — retrieves a list of seismic stations and their details
-router.get('/')
+router.get('/', getAllStations({ buildResponse, handleHttpError }))
 
 // NOTE: Returns a single seismic station by code
 // GET /:code — retrieves details of a specific seismic station identified by its code

--- a/backend/src/services/ingvStationService.js
+++ b/backend/src/services/ingvStationService.js
@@ -1,0 +1,55 @@
+import axios from 'axios'
+import dotenv from 'dotenv'
+import xml2js from 'xml2js'
+
+// Load environment variables from .env file
+dotenv.config()
+
+// Base URL for the INGV FDSN Station web service
+const INGV_STATION_BASE_URL =
+  process.env.URL_INGV_STATION || 'https://webservices.ingv.it/fdsnws/station/1/query'
+
+/**
+ * Fetches seismic stations from INGV FDSN web service.
+ * @param {Object} options - Options for the API request
+ * @param {string} options.network - Network code to filter stations (default: 'IV' for Italian network)
+ * @param {string} options.format - Response format, 'xml' by default
+ * @returns {Array} Array of station objects retrieved from INGV
+ */
+export async function fetchINGVStations ({ network = 'IV', format = 'xml' } = {}) {
+  try {
+    // Construct the full API URL with query parameters
+    const url = `${INGV_STATION_BASE_URL}?network=${network}&level=station&format=${format}`
+
+    // Make HTTP GET request to INGV API
+    const resp = await axios.get(url)
+
+    // If the response is XML (as string), parse it into JSON
+    if (typeof resp.data === 'string') {
+      const parser = new xml2js.Parser({ explicitArray: false })
+      const parsed = await parser.parseStringPromise(resp.data)
+
+      // Extract networks from the parsed XML
+      const networks = parsed?.FDSNStationXML?.Network
+      if (!networks) return [] // Return empty array if no networks found
+
+      // Ensure networks is always an array, even if only one network
+      const netArray = Array.isArray(networks) ? networks : [networks]
+
+      // Flatten all stations from all networks into a single array
+      const stations = netArray.flatMap(n => n.Station || [])
+
+      // Return the array of station objects
+      return stations
+    }
+
+    // Return empty array if data is not a string (unexpected format)
+    return []
+  } catch (error) {
+    // Log any errors to the console for debugging
+    console.error('Error fetching INGV stations:', error.message)
+
+    // Return empty array on error to prevent application crash
+    return []
+  }
+}


### PR DESCRIPTION
This PR adds support for fetching seismic stations from the INGV FDSN web service in the backend.

**Changes:**
- Created service `fetchINGVStations` that retrieves station data via Axios
- Converted XML response to JSON using xml2js
- Implemented `getAllStations` controller with optional `limit` query parameter
- Added pagination info (limit, total stations, hasMore) in API response
- Added proper error handling for API failures

This allows the frontend dashboard and admin interface to query seismic stations directly from INGV.
