### PR TITLE
docs(api): update README URL and add base structure for Earthquakes A…

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Visit `http://localhost:5173` for the frontend interface and `http://localhost:5
 
 ## API Reference
 
-The TerraQuake API provides various endpoints for querying earthquake data. For detailed usage, examples, and testing, visit the [API Docs](https://api.terraquakeapi.com/v1/docs).
+The TerraQuake API provides various endpoints for querying earthquake data. For detailed usage, examples, and testing, visit the [API Docs](https://api.terraquakeapi.com/v1/earthquakes/docs).
 
 ## 🌍 Earthquake API Endpoints
 

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -15,6 +15,7 @@ import routeContact from './routes/contactRoutes.js'
 import routeGetStart from './routes/testRoutes.js'
 import routeEarthquakes from './routes/earthquakesRoutes.js'
 import routeStation from './routes/stationsRoutes.js'
+import routeDocsEarthquakes from './routes/docsEarthquakesRoutes.js'
 import routeGitHub from './routes/githubAuthRoutes.js'
 import newsletterRoutes from './routes/newsletterRoutes.js'
 import dbConnect from './config/mongoConfig.js'
@@ -60,6 +61,7 @@ app.use(cors({
 
 // Public route: earthquakes data, accessible from any origin
 app.use('/v1/earthquakes', cors({ origin: '*' }), apiLimiter, routeEarthquakes)
+app.use('/v1/earthquakes', cors({ origin: '*' }), apiLimiter, routeDocsEarthquakes)
 app.use('/v1/stations', cors({ origin: '*' }), apiLimiter, routeStation)
 
 // Protected routes

--- a/backend/src/controllers/docsEarthquakesControlles.js
+++ b/backend/src/controllers/docsEarthquakesControlles.js
@@ -1,0 +1,24 @@
+/** NOTE: viewDocsEarthquakes
+ * This controller handles requests for viewing the Earthquake API documentation.
+ * It builds a structured response containing available documentation data.
+ * If an error occurs during processing, it is handled gracefully using handleHttpError.
+ */
+export const viewDocsEarthquakes = ({
+  buildResponse,
+  handleHttpError
+}) => {
+  return async (req, res) => {
+    try {
+      const docsEarthquakes = {}
+
+      // Send a successful response containing the documentation data
+      return res.status(200).json(
+        buildResponse(req, 'Earthquake API Documentation retrieved successfully', docsEarthquakes, null, {})
+
+      )
+    } catch (error) {
+      console.error(error.message)
+      handleHttpError(res, 'An internal server error occurred.', 500)
+    }
+  }
+}

--- a/backend/src/routes/docsEarthquakesRoutes.js
+++ b/backend/src/routes/docsEarthquakesRoutes.js
@@ -1,0 +1,13 @@
+import express from 'express'
+import { buildResponse } from '../utils/buildResponse.js'
+import handleHttpError from '../utils/handleHttpError.js'
+import { viewDocsEarthquakes } from '../controllers/docsEarthquakesControlles.js'
+
+const router = express.Router()
+
+// NOTE: Serve the Earthquake API documentation
+// This endpoint provides access to the API reference and usage examples.
+// It leverages the viewDocsEarthquakes controller to render or return documentation data.
+router.get('/docs', viewDocsEarthquakes({ buildResponse, handleHttpError }))
+
+export default router


### PR DESCRIPTION
Description:
This PR introduces the foundational setup for the Earthquakes API documentation.

**Key changes include:**

- Updated the documentation link in README.md to the production endpoint.
- Added a new route and controller to serve /earthquakes/docs.
- Established the groundwork for displaying API usage instructions and available endpoints.