### PR TITLE
feat(auth): extend Google OAuth strategy with additional user fields …

### DIFF
--- a/backend/src/controllers/githubController.js
+++ b/backend/src/controllers/githubController.js
@@ -75,6 +75,15 @@ export const githubAuthController = ({ handleHttpError }) => {
           name: githubUser.name || githubUser.login,
           email: primaryEmail || null,
           avatar: githubUser.avatar_url,
+          experience: '',
+          student: 'No',
+          location: '',
+          website: '',
+          portfolio: '',
+          github: '',
+          linkedin: '',
+          bio: '',
+          terms: true,
           role: ['user']
         })
       }

--- a/backend/src/models/userModels.js
+++ b/backend/src/models/userModels.js
@@ -48,32 +48,39 @@ const usersSchema = new Schema(
     },
     githubId: {
       type: String,
+      default: '',
       unique: true
     },
     githubProfileUrl: {
       type: String
     },
     bio: {
-      type: String
+      type: String,
+      default: ''
     },
     location: {
       type: String,
+      default: '',
       trim: true
     },
     website: {
       type: String,
+      default: '',
       trim: true
     },
     portfolio: {
       type: String,
+      default: '',
       trim: true
     },
     github: {
       type: String,
+      default: '',
       trim: true
     },
     linkedin: {
       type: String,
+      default: '',
       trim: true
     }
   },


### PR DESCRIPTION
**Description:**
This PR updates the Google OAuth strategy to align user creation with the standard registration model and improve data consistency.

**Key changes:**

Added the following fields to the user object during first-time authentication via Google:
experience, student, location, website, portfolio, github, linkedin, bio, terms, and role.

Set default values ('' for strings, true for terms, ['user'] for role) for all optional fields.

Ensures that profiles created via Google OAuth are complete and consistent with manually registered profiles.