### PR TITLE
feat: unify OAuth callback for GitHub and Google

### DIFF
--- a/frontend/src/pages/auth/GithubAuth.jsx
+++ b/frontend/src/pages/auth/GithubAuth.jsx
@@ -7,10 +7,8 @@ import { motion } from 'framer-motion';
 export default function GithubAuth() {
   const navigate = useNavigate();
   const { search } = useLocation();
-  const { setUserLogin, setIsLoggedIn } = useContext(Context);
+  const { setIsLoggedIn } = useContext(Context);
   const [loading, setLoading] = useState(false);
-
-  const BACKEND_URL = import.meta.env.VITE_URL_BACKEND;
 
   useEffect(() => {
     setLoading(true);
@@ -19,54 +17,31 @@ export default function GithubAuth() {
     const message = params.get('message');
 
     if (token) {
+      // Salva il token in localStorage
       localStorage.setItem('token', token);
 
-      fetch(`${BACKEND_URL}/users/me`, {
-        headers: { Authorization: `Bearer ${token}` },
-      })
-        .then((res) => res.json())
-        .then((data) => {
-          if (data?.user) {
-            localStorage.setItem('user', JSON.stringify(data.user));
+      // Imposta utente come loggato
+      setIsLoggedIn(true);
 
-            setUserLogin(data.user);
-            setIsLoggedIn(true);
-
-            Swal.fire({
-              title: 'Success!',
-              text: message || 'Login with GitHub successful!',
-              icon: 'success',
-              confirmButtonText: 'Profile',
-            }).then(() => {
-              setLoading(false);
-              navigate('/profile', { replace: true });
-            });
-          } else {
-            throw new Error('Invalid user data');
-          }
-        })
-        .catch((err) => {
-          const errorMessage =
-            err?.response?.data?.message ||
-            err?.response?.data?.error ||
-            err.message ||
-            'Login failed. Please try again.';
-
-          Swal.fire({
-            title: 'Error!',
-            text: errorMessage,
-            icon: 'error',
-            confirmButtonText: 'Ok',
-          }).then(() => {
-            navigate('/signin');
-            setLoading(false);
-          });
-        });
+      Swal.fire({
+        title: 'Success!',
+        text: message || 'Login with GitHub successful!',
+        icon: 'success',
+        confirmButtonText: 'Profile',
+      }).then(() => {
+        setLoading(false);
+        navigate('/profile', { replace: true });
+      });
     } else {
       setLoading(false);
-      navigate('/signin');
+      Swal.fire({
+        title: 'Error!',
+        text: 'No token received. Please try signing in again.',
+        icon: 'error',
+        confirmButtonText: 'Ok',
+      }).then(() => navigate('/signin'));
     }
-  }, [search, navigate, BACKEND_URL, setUserLogin, setIsLoggedIn]);
+  }, [search, navigate, setIsLoggedIn]);
 
   if (loading) {
     return (
@@ -77,7 +52,6 @@ export default function GithubAuth() {
         className='fixed inset-0 flex flex-col items-center justify-center
         bg-gradient-to-br from-[#0a0a0a] via-[#1a1a1a] to-[#2d2d2d] z-50'
       >
-        {/* Background Gradient/Mesh (for a classy, dark theme) */}
         <div className='absolute inset-0 z-0'>
           <div className='absolute top-0 left-0 w-80 h-80 bg-purple-500 rounded-full mix-blend-multiply filter blur-3xl opacity-30 animate-blob' />
           <div className='absolute bottom-10 right-10 w-96 h-96 bg-pink-500 rounded-full mix-blend-multiply filter blur-3xl opacity-30 animate-blob animation-delay-2000' />

--- a/frontend/src/pages/auth/HandleOAuth.jsx
+++ b/frontend/src/pages/auth/HandleOAuth.jsx
@@ -56,7 +56,7 @@ export default function HandleOAuth() {
       // Redirect after success
       Swal.fire({
         title: 'Login Successful!',
-        text: 'You have been logged in.',
+        text: message || 'Login with Google successful!',
         icon: 'success',
         confirmButtonText: 'Profile',
       }).then(() => {


### PR DESCRIPTION
- Removed fetch to /users/me; token is read directly from query string.
- Saves token in localStorage and sets isLoggedIn in Context.
- Provides dynamic success messages and loading state with Framer Motion animation.