### PR TITLE
feat: hide 'Change Password' for OAuth users and add GitHub Stars com…

### DIFF
--- a/frontend/src/components/navbar/NavbarMenu.jsx
+++ b/frontend/src/components/navbar/NavbarMenu.jsx
@@ -1,19 +1,17 @@
 import React, { useState, useContext, useEffect, useRef } from 'react';
 import Sismic from '@images/tracciato.png';
 import { FaChevronDown, FaBars, FaTimes } from 'react-icons/fa';
-import { FiGithub } from 'react-icons/fi';
 import { Link, NavLink, useNavigate } from 'react-router-dom';
 import { Context } from '@components/modules/Context';
-import axios from 'axios';
 import AvatarUser from '../utils/AvatarUser';
 import Logout from '@/pages/auth/Logout';
+import StarsGitHub from '../utils/StarsGitHub';
 
 export default function NavbarMenu() {
-  const navigate = useNavigate()
+  const navigate = useNavigate();
   const { userLogin, isLoggedIn, setIsLoggedIn, setUserLogin } =
-    useContext(Context)
+    useContext(Context);
 
-  const [stars, setStars] = useState(0);
   const [isMobileOpen, setIsMobileOpen] = useState(false);
   const [isResourcesOpen, setIsResourcesOpen] = useState(false);
   const [isProfileOpen, setIsProfileOpen] = useState(false);
@@ -39,40 +37,25 @@ export default function NavbarMenu() {
 
   const profileItems = [
     { name: 'Profile', path: '/profile' },
+    { name: 'Admin Dashboard', path: '/admin' },
     { name: 'Change Password', path: '/change-password' },
     { name: 'Messages', path: '/contact' },
     { name: 'Documentation', path: '/docs' },
     { name: 'Information', path: '/info' },
-  ]
-
-  useEffect(() => {
-    const urlGitHub = 'https://api.github.com/repos/nagcas/TerraQuakeApi'
-    let mounted = true
-    axios
-      .get(urlGitHub)
-      .then(({ data }) => {
-        if (mounted) setStars(data?.stargazers_count ?? 0)
-      })
-      .catch((err) => {
-        console.error('GitHub stars fetch error', err?.message ?? err)
-      })
-    return () => {
-      mounted = false
-    }
-  }, [])
+  ];
 
   useEffect(() => {
     function onDocClick(e) {
       if (resourcesRef.current && !resourcesRef.current.contains(e.target))
         setIsResourcesOpen(false);
       if (profileRef.current && !profileRef.current.contains(e.target))
-        setIsProfileOpen(false)
+        setIsProfileOpen(false);
       if (mobileRef.current && !mobileRef.current.contains(e.target))
-        setIsMobileOpen(false)
+        setIsMobileOpen(false);
     }
-    document.addEventListener('mousedown', onDocClick)
-    return () => document.removeEventListener('mousedown', onDocClick)
-  }, [])
+    document.addEventListener('mousedown', onDocClick);
+    return () => document.removeEventListener('mousedown', onDocClick);
+  }, []);
 
   return (
     <header className='fixed top-0 left-0 w-full backdrop-blur-2xl bg-black/60 text-white shadow-lg py-4 px-4 flex items-center justify-between lg:justify-around z-50'>
@@ -165,22 +148,14 @@ export default function NavbarMenu() {
 
       {/* Auth / profile area */}
       <div className='lg:flex items-center ml-2 gap-3 text-[14px] lg:text-[16px] relative'>
-        <a
-          href='https://github.com/nagcas/TerraQuakeApi'
-          target='_blank'
-          rel='noopener noreferrer'
-          className='hidden lg:flex items-center gap-2 bg-gradient-to-r from-gray-900/80 to-gray-800/80 border border-gray-600/50 rounded-full px-3 py-1.5 shadow-lg transition-all hover:scale-105 hover:border-purple-500/50 transform duration-200'
-        >
-          <span className='flex items-center gap-1.5 text-gray-300 font-medium text-sm'>
-            <FiGithub className='text-purple-400 text-lg' /> Stars
-          </span>
-          <span className='bg-purple-600 text-white font-semibold px-2 py-0.5 rounded-md shadow-md text-xs'>
-            {stars}
-          </span>
-        </a>
+        {/* Stars GitHub TerraQuake API*/}
+        <StarsGitHub />
 
         {isLoggedIn ? (
-          <div ref={profileRef} className='relative'>
+          <div
+            ref={profileRef}
+            className='relative'
+          >
             <button
               onClick={() => setIsProfileOpen((s) => !s)}
               className='flex items-center gap-2 hover:bg-gray-800/50 rounded-lg px-2 py-1 transition-colors duration-200 cursor-pointer'
@@ -203,29 +178,47 @@ export default function NavbarMenu() {
                 className='absolute top-full right-0 mt-2 w-52 bg-black/95 backdrop-blur-xl border border-purple-500/50 rounded-2xl shadow-lg z-50 py-2 animate-fade-in'
                 onClick={(e) => e.stopPropagation()}
               >
-                {profileItems.map((item) => (
-                  <NavLink
-                    key={item.name}
-                    to={item.path}
-                    onClick={() => setIsProfileOpen(false)}
-                    className={({ isActive }) =>
-                      `block px-4 py-2 text-sm hover:text-purple-400 hover:bg-purple-500/10 transition-colors duration-200 ${
-                        isActive
-                          ? 'text-purple-400 font-semibold bg-purple-500/20'
-                          : 'text-gray-300'
-                      } ${
-                        item.name === 'Admin Dashboard'
-                          ? 'border-l-2 border-purple-500 bg-purple-500/5'
-                          : ''
-                      }`
-                    }
-                  >
-                    {item.name === 'Admin Dashboard' && (
-                      <span className='text-purple-400 mr-2'>👑</span>
-                    )}
-                    {item.name}
-                  </NavLink>
-                ))}
+                {profileItems.map((item) => {
+                  // If the item is Admin Dashboard but the user is NOT admin, we don't show it
+                  if (
+                    item.name === 'Admin Dashboard' &&
+                    userLogin.role[0] !== 'admin'
+                  ) {
+                    return null;
+                  }
+
+                  // Hide Change Password when logging in via Google or GitHub
+                  if (
+                    item.name === 'Change Password' &&
+                    (userLogin.githubId || userLogin.googleId)
+                  ) {
+                    return null;
+                  }
+
+                  return (
+                    <NavLink
+                      key={item.name}
+                      to={item.path}
+                      onClick={() => setIsProfileOpen(false)}
+                      className={({ isActive }) =>
+                        `block px-4 py-2 text-sm hover:text-purple-400 hover:bg-purple-500/10 transition-colors duration-200 ${
+                          isActive
+                            ? 'text-purple-400 font-semibold bg-purple-500/20'
+                            : 'text-gray-300'
+                        }`
+                      }
+                    >
+                      {item.name === 'Admin Dashboard' ? (
+                        <span className='text-purple-400 mr-2'>
+                          👑 {item.name}
+                        </span>
+                      ) : (
+                        item.name
+                      )}
+                    </NavLink>
+                  );
+                })}
+
                 <hr className='border-t border-purple-500/40 my-2' />
                 <div className='flex justify-center mb-2'>
                   <Logout />
@@ -300,8 +293,8 @@ export default function NavbarMenu() {
               <button
                 className='border border-gray-400 text-gray-300 font-medium py-2 px-6 rounded-full w-full max-w-[260px]'
                 onClick={() => {
-                  navigate('/signin')
-                  setIsMobileOpen(false)
+                  navigate('/signin');
+                  setIsMobileOpen(false);
                 }}
               >
                 Sign In
@@ -309,8 +302,8 @@ export default function NavbarMenu() {
               <button
                 className='bg-gradient-to-r from-pink-500 to-purple-600 py-2 px-6 rounded-full w-full max-w-[260px]'
                 onClick={() => {
-                  navigate('/signup')
-                  setIsMobileOpen(false)
+                  navigate('/signup');
+                  setIsMobileOpen(false);
                 }}
               >
                 Sign Up
@@ -320,5 +313,5 @@ export default function NavbarMenu() {
         </div>
       </div>
     </header>
-  )
+  );
 }

--- a/frontend/src/components/utils/StarsGitHub.jsx
+++ b/frontend/src/components/utils/StarsGitHub.jsx
@@ -1,0 +1,40 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import { FiGithub } from 'react-icons/fi';
+
+export default function StarsGitHub() {
+  const [stars, setStars] = useState(0);
+
+  useEffect(() => {
+    const urlGitHub = 'https://api.github.com/repos/nagcas/TerraQuakeApi';
+    let mounted = true;
+    axios
+      .get(urlGitHub)
+      .then(({ data }) => {
+        if (mounted) setStars(data?.stargazers_count ?? 0);
+      })
+      .catch((err) => {
+        console.error('GitHub stars fetch error', err?.message ?? err);
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+  return (
+    <div>
+      <a
+        href='https://github.com/nagcas/TerraQuakeApi'
+        target='_blank'
+        rel='noopener noreferrer'
+        className='hidden lg:flex items-center gap-2 bg-gradient-to-r from-gray-900/80 to-gray-800/80 border border-gray-600/50 rounded-full px-3 py-1.5 shadow-lg transition-all hover:scale-105 hover:border-purple-500/50 transform duration-200'
+      >
+        <span className='flex items-center gap-1.5 text-gray-300 font-medium text-sm'>
+          <FiGithub className='text-purple-400 text-lg' /> Stars
+        </span>
+        <span className='bg-purple-600 text-white font-semibold px-2 py-0.5 rounded-md shadow-md text-xs'>
+          {stars}
+        </span>
+      </a>
+    </div>
+  );
+}


### PR DESCRIPTION
This PR introduces two main improvements to the TerraQuake frontend:

### Profile Menu Logic Update

- The “Change Password” option is now hidden for users authenticated through Google or GitHub OAuth.
- The “Admin Dashboard” link is only displayed for users with the "admin" role.
- This ensures a cleaner and more relevant user interface based on login type and permissions.

### New GitHub Stars Component

- Added a new <Stars /> component to display the GitHub repository stars count dynamically.
- The component fetches data directly from the GitHub API and is imported into the Navbar.
- This refactor keeps the Navbar lean, modular, and easier to maintain.

### Technical details:

- Conditional rendering implemented in profileItems.map() based on user role and OAuth provider.
- <Stars /> uses fetch or axios to read repository data from GitHub’s REST API.
- Minor UI adjustments for consistent styling and layout within the Navbar.

### Why this update matters:

- Enhances user experience by displaying only relevant actions.
- Improves component structure and maintainability.
- Introduces an engaging feature that highlights the community activity around the project.

### Next steps:

Consider adding loading and error states in the <Stars /> component.
Optionally display forks or contributors count alongside stars.