### PR TITLE
fix(navbar): prevent user menu from auto-opening after login

### DIFF
--- a/frontend/src/components/navbar/NavbarMenu.jsx
+++ b/frontend/src/components/navbar/NavbarMenu.jsx
@@ -44,6 +44,11 @@ export default function NavbarMenu() {
     { name: 'Information', path: '/info' },
   ];
 
+  // Automatically close the profile menu when the login status changes
+  useEffect(() => {
+    setIsProfileOpen(false);
+  }, [isLoggedIn]);
+
   useEffect(() => {
     function onDocClick(e) {
       if (resourcesRef.current && !resourcesRef.current.contains(e.target))


### PR DESCRIPTION
Added a useEffect to automatically close the profile dropdown when the login state changes (`isLoggedIn`). This prevents the profile menu from appearing immediately after a successful login or logout.