### PR TITLE
Add TerraQuake SweetAlert2 custom dark theme with animated alerts

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -132,3 +132,69 @@ body {
 .group:hover .icon-bounces {
   animation: subtle-bounce 0.8s infinite;
 }
+
+/* SweetAlert2 TerraQuake Custom Theme */
+.swal2-popup {
+  background: #1e1917 !important; /* warm volcanic dark */
+  color: #f3f4f6 !important;
+  border-radius: 1rem !important;
+  font-family: "Poppins", sans-serif;
+  box-shadow: 0 0 20px rgba(147, 51, 234, 0.2); /* soft purple glow */
+  animation: quakeFadeIn 0.45s ease forwards;
+}
+
+
+.swal2-confirm,
+.swal2-cancel {
+  border-radius: 0.75rem !important;
+  font-weight: 600 !important;
+  transition: all 0.3s ease !important;
+}
+
+.swal2-confirm {
+  background-color: #9333ea !important; /* purple quake accent */
+  color: #fff !important;
+}
+
+.swal2-confirm:hover {
+  background-color: #7e22ce !important;
+  transform: scale(1.05);
+}
+
+.swal2-cancel {
+  background-color: #3f3f46 !important;
+  color: #f3f4f6 !important;
+}
+
+.swal2-cancel:hover {
+  background-color: #52525b !important;
+}
+
+/* Animations */
+@keyframes quakeFadeIn {
+  0% {
+    opacity: 0;
+    transform: scale(0.85) translateY(10px);
+    box-shadow: 0 0 0 rgba(147, 51, 234, 0);
+  }
+  70% {
+    opacity: 1;
+    transform: scale(1.03) translateY(-2px);
+    box-shadow: 0 0 30px rgba(147, 51, 234, 0.25);
+  }
+  100% {
+    transform: scale(1) translateY(0);
+    box-shadow: 0 0 20px rgba(147, 51, 234, 0.2);
+  }
+}
+
+/* Optional subtle shake when alert appears (quake effect) */
+.swal2-show {
+  animation: quakeShake 0.4s ease;
+}
+
+@keyframes quakeShake {
+  0%, 100% { transform: translateX(0); }
+  20%, 60% { transform: translateX(-4px); }
+  40%, 80% { transform: translateX(4px); }
+}


### PR DESCRIPTION
### Summary
Introduced a custom SweetAlert2 theme for TerraQuake with a dark volcanic background, soft purple glow, and smooth fade-in animation.
This improves visual consistency across all alert dialogs and aligns with the TerraQuake color palette.

### Details
- Added dark background (#1e1917) and soft light text.
- Added smooth `fade + scale` entrance animation.
- Customized confirm/cancel button colors.
- Included optional subtle quake-shake effect for alert entrance.

### Result
All SweetAlert2 popups now match the TerraQuake design identity, providing a more cohesive and modern user experience.
