### PR TITLE
Fix: corrected email property in ForgotPassword response handling

### DIFF
--- a/frontend/src/pages/auth/ForgotPassword.jsx
+++ b/frontend/src/pages/auth/ForgotPassword.jsx
@@ -14,7 +14,7 @@ export default function forgotPassword() {
   const [loading, setLoading] = useState(false);
   const forgotPasswordSchema = yup
     .object({
-      email: yup.string().email().required('Email is required !'),
+      email: yup.string().email().required('Email is required!'),
     })
     .required();
 
@@ -41,7 +41,7 @@ export default function forgotPassword() {
       .then((res) => {
         localStorage.setItem(
           'passwordChangeRequestingEmail',
-          res.data.user.email
+          res.data.data.email
         );
         Swal.fire({
           title: 'Success!',


### PR DESCRIPTION
### Summary
This PR fixes an issue in the Forgot Password flow where the frontend attempted 
to read `res.data.user.email`, resulting in a TypeError because `user` was undefined.

### Changes
- Updated localStorage assignment to use the correct response structure: 
  `res.data.data.email`

### Result
The email is now properly stored in localStorage, and the forgot password flow 
works without runtime errors.
