### PR TITLE
feat(faq): implement getFaqById with admin-only route protection

### DIFF
--- a/backend/src/routes/faqRoutes.js
+++ b/backend/src/routes/faqRoutes.js
@@ -31,7 +31,7 @@ router.get('/list-all-faq', listAllFaq({ Faq, buildResponse, handleHttpError }))
  * @desc Retrieve a single FAQ entry by its ID.
  * @access Private (Admin only)
  */
-router.get('/list-one-faq/:id', adminMiddleware, listOneFaq({ Faq }))
+router.get('/list-one-faq/:id', adminMiddleware, listOneFaq({ Faq, buildResponse, handleHttpError, invalidateToken }))
 
 /**
  * @route PATCH /update-faq/:id


### PR DESCRIPTION
### Summary
Added functionality to fetch a specific FAQ by its ID, accessible only to admin users.
This ensures controlled access to detailed FAQ information while maintaining data security.

### Changes
- Created `getFaqById` controller to handle fetching FAQs by ID
- Added a protected route requiring admin privileges
- Integrated authorization middleware for role-based access
- Implemented error handling for missing or invalid IDs

### Testing
- Verified with Postman using valid admin credentials
- Confirmed access is denied for non-admin users
- Checked responses for valid and invalid FAQ IDs
