### PR TITLE
feat: add API version endpoint and VersionAPI component

### DIFF
--- a/frontend/src/components/footer/Footer.jsx
+++ b/frontend/src/components/footer/Footer.jsx
@@ -2,6 +2,7 @@ import { motion } from 'framer-motion';
 import { NavLink } from 'react-router-dom';
 import Socials from '../socials/Socials';
 import Copyright from '../copyright/Copyright';
+import VersionAPI from '../utils/VersionAPI';
 
 export default function Footer() {
   const navLinks = [
@@ -100,7 +101,11 @@ export default function Footer() {
 
         {/* Social / Sponsor */}
         <Socials />
+
       </div>
+      
+      {/* Version API */}
+      <VersionAPI />
 
       {/* Copyright + Extended License */}
       <Copyright />

--- a/frontend/src/components/utils/VersionAPI.jsx
+++ b/frontend/src/components/utils/VersionAPI.jsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react';
+import axios from '@config/Axios.js';
+import Spinner from '../spinner/Spinner';
+
+export default function VersionAPI() {
+  const [api, setApi] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    fetchVersion();
+  }, []);
+
+  const fetchVersion = async () => {
+    setLoading(true);
+    try {
+      const response = await axios('/v1/test', {
+        headers: { 'Content-Type': 'application/json' },
+      });
+      setApi(response.data);
+    } catch (error) {
+      console.error('Error fetching API version:', error.response?.data || error.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (loading) return <Spinner />;
+
+  if (!api) return null;
+
+  return (
+    <section className="my-4">
+      <div className="max-w-md md:max-w-[1024px] mx-auto bg-white-800/2 backdrop-blur-md rounded-lg shadow-lg p-4 flex flex-col gap-4 text-white">
+        <h3 className="text-lg font-bold text-purple-400">API Information</h3>
+        <div className="flex flex-col items-center sm:flex-row sm:justify-between gap-4 sm:gap-4">
+          <div className="bg-purple-400/20 py-2 px-6 rounded-md text-black font-semibold">
+            Version: <p className="font-bold">{api.version}</p>
+          </div>
+          <div className="text-sm text-gray-300">
+            Last updated: <p className="font-medium">{api.date}</p>
+          </div>
+          <div className="text-sm text-gray-300">
+            Author: <p className="font-medium">{api.author}</p>
+          </div>
+          <div className="text-sm text-gray-300">
+            Project: <p className="font-medium">{api.project}</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/frontend/src/pages/docs/Docs.jsx
+++ b/frontend/src/pages/docs/Docs.jsx
@@ -5,6 +5,7 @@ import { motion } from 'framer-motion';
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { atomOneDark } from 'react-syntax-highlighter/dist/esm/styles/hljs';
 import { CopyButton } from './CopyButton';
+import VersionAPI from '@/components/utils/VersionAPI';
 
 export default function Docs() {
   const contentRef = useRef(null);
@@ -13,6 +14,7 @@ export default function Docs() {
 
   const sections = useMemo(
     () => [
+      { id: 'api-information', label: 'API Information' },
       { id: 'getting-started', label: 'Getting Started' },
       { id: 'common-parameters', label: 'Common Parameters' },
       { id: 'response-format', label: 'Response Format' },
@@ -160,13 +162,6 @@ export default function Docs() {
                     </li>
                   ))}
                 </ul>
-                {/* Quick links (small footer in sidebar) */}
-                <div className='mt-4 text-xs text-white/60'>
-                  <div>
-                    API Version: <strong>1.0</strong>
-                  </div>
-                  <div className='mt-2'>Last updated: October 2025</div>
-                </div>
               </nav>
             </aside>
 
@@ -175,6 +170,15 @@ export default function Docs() {
               ref={contentRef}
               className='col-span-1 lg:col-span-9 prose prose-invert max-w-none'
             >
+              {/* API Information */}
+               <section
+                id='api-information'
+                className='scroll-mt-28'
+              >
+                <VersionAPI />
+              </section>
+              
+
               {/* Getting Started */}
               <section
                 id='getting-started'


### PR DESCRIPTION
This PR introduces a new backend endpoint `v1/test` that provides information about the API version, last updated date, author, and project name. 

A reusable React component `VersionAPI` has been created to display this information in the frontend. It includes:

- Loading state handling with a spinner
- Responsive layout using Tailwind
- Display of version, date, and author in a card-style UI

Currently, the component is used in the Docs page and Footer for easy reference.

This setup allows the version info to be displayed wherever needed across the app.
