### PR TITLE
fix(scroll): add current page dependency to useEffect for users, post…

### DIFF
--- a/frontend/src/pages/adminDashboard/faq/TableFaqs.jsx
+++ b/frontend/src/pages/adminDashboard/faq/TableFaqs.jsx
@@ -28,7 +28,7 @@ export default function TableFaqs() {
 
   useEffect(() => {
     window.scrollTo(0, 0);
-  }, []);
+  }, [currentPageFaq]);
 
   return (
     <>

--- a/frontend/src/pages/adminDashboard/messages/TableMessages.jsx
+++ b/frontend/src/pages/adminDashboard/messages/TableMessages.jsx
@@ -26,7 +26,7 @@ export default function TableMessages() {
 
   useEffect(() => {
     window.scrollTo(0, 0);
-  }, []);
+  }, [currentPageMessage]);
 
   return (
     <>

--- a/frontend/src/pages/adminDashboard/posts/TablePosts.jsx
+++ b/frontend/src/pages/adminDashboard/posts/TablePosts.jsx
@@ -28,7 +28,7 @@ export default function TablePosts() {
 
   useEffect(() => {
     window.scrollTo(0, 0);
-  }, []);
+  }, [currentPagePost]);
 
   return (
     <>

--- a/frontend/src/pages/adminDashboard/users/TableUsers.jsx
+++ b/frontend/src/pages/adminDashboard/users/TableUsers.jsx
@@ -26,7 +26,7 @@ export default function TableUsers() {
 
   useEffect(() => {
     window.scrollTo(0, 0);
-  }, []);
+  }, [currentPageUser]);
 
   return (
     <>


### PR DESCRIPTION
…s, faqs, and messages

- Ensured that window.scrollTo(0, 0) triggers correctly when changing pages.
- Added `currentPageUser`, `currentPagePost`, `currentPageFaq`, and `currentPageMessage` as dependencies in useEffect hooks.
- Improved UX by automatically scrolling to top on pagination change across all sections.