### PR TITLE
feat(metrics): add Metrics model and implement cumulative event track…

### DIFF
--- a/backend/src/models/metricsModels.js
+++ b/backend/src/models/metricsModels.js
@@ -1,0 +1,40 @@
+import { Schema, model } from 'mongoose'
+
+// NOTE: Schema matrics
+const metricsSchema = new Schema(
+  {
+    eventsProcessed:
+    {
+      type: Number,
+      default: 0
+    },
+    totalEventsProcessed:
+    {
+      type: Number,
+      default: 0
+    }, // cumulative counter
+    apiLatencyAvgMs:
+    {
+      type: Number
+    },
+    uptime:
+    {
+      type: Number
+    },
+    memoryUsage:
+    {
+      type: Number
+    }
+  },
+  {
+    timestamps: true,
+    versionKey: false,
+    collection: 'metrics'
+  }
+)
+
+// Creating the metrics model based on the metricsSchema schema
+const Metrics = model('metrics', metricsSchema)
+
+// Exporting the metrics model
+export default Metrics

--- a/backend/src/routes/metricsRouters.js
+++ b/backend/src/routes/metricsRouters.js
@@ -4,15 +4,18 @@
 
 import express from 'express'
 import { getMetrics, getMetricsJSON } from '../controllers/metricsControllers.js'
+import Metrics from '../models/metricsModels.js'
+import { buildResponse } from '../utils/buildResponse.js'
+import handleHttpError from '../utils/handleHttpError.js'
 
 const router = express.Router()
 
 // NOTE: GET /metrics endpoint
 // Returns system and API performance metrics collected by prom-client
-// SECURED: Admin-only access to system metrics
 router.get('/metrics', getMetrics)
 
-// SECURED: Admin-only access to JSON metrics
-router.get('/metrics/json', getMetricsJSON)
+// NOTE: GET /metrics/json endpoint
+// Returns system and API performance JSON metrics
+router.get('/metrics/json', getMetricsJSON({ Metrics, buildResponse, handleHttpError }))
 
 export default router

--- a/frontend/src/components/metrics/Metrics.jsx
+++ b/frontend/src/components/metrics/Metrics.jsx
@@ -6,6 +6,8 @@ export default function Metrics() {
   const [loadingMetrics, setLoadingMetrics] = useState(true);
   const [metricsError, setMetricsError] = useState(null);
 
+  const [totalEventsProcessed, setTotalEventsProcessed] = useState(0);
+
   useEffect(() => {
     let firstLoad = true;
 
@@ -19,9 +21,11 @@ export default function Metrics() {
 
         const { payload } = response.data;
 
+        setTotalEventsProcessed(payload.totalEventsProcessed);
+
         setHighlightMetrics([
           {
-            value: payload.eventsProcessed?.toLocaleString() || 'N/A',
+            value: payload.totalEventsProcessed?.toLocaleString('it-IT') || 'N/A',
             label: 'Events Processed',
             description: 'Real-time earthquakes normalized and accessible',
           },
@@ -29,11 +33,6 @@ export default function Metrics() {
             value: `${payload.apiLatencyAvgMs} ms`,
             label: 'API Latency',
             description: 'Average API response time',
-          },
-          {
-            value: `${Math.floor(payload.uptime)} s`,
-            label: 'Uptime',
-            description: 'Time since last server restart',
           },
           {
             value: '24/7',
@@ -73,10 +72,10 @@ export default function Metrics() {
   if (metricsError) {
     return (
       <section className='p-6 md:p-0 text-center text-gray-300'>
-        <h2 className='text-3xl md:text-4xl font-bold text-red-500 my-16'>
+        <h2 className='text-3xl md:text-4xl font-bold text-red-400 my-6'>
           Failed to Load Metrics
         </h2>
-        <p>{metricsError}</p>
+        <p className='mb-16'>{metricsError}</p>
       </section>
     );
   }
@@ -87,7 +86,7 @@ export default function Metrics() {
         System Performance and Reliability Metrics
       </h2>
 
-      <div className='max-w-7xl mx-auto grid gap-4 grid-cols-2 p-6 xl:grid-cols-4 mb-6 md:mb-[150px]'>
+      <div className='max-w-7xl mx-auto grid gap-4 grid-cols-2 p-6 xl:grid-cols-3 mb-6 md:mb-[150px]'>
         {highlightMetrics.map((metric) => (
           <div
             key={metric.label}


### PR DESCRIPTION
### Summary
This PR introduces persistent metric tracking for the TerraQuake API. It ensures that the total number of processed events is *not lost* when the server or Prometheus counter resets.

### Key Changes
- Created `Metrics` MongoDB model with fields:
  - `eventsProcessed`: last known Prometheus snapshot
  - `totalEventsProcessed`: cumulative persistent counter
  - `apiLatencyAvgMs`, `uptime`, `memoryUsage`

- Updated `getMetricsJSON` controller:
  - Reads current Prometheus metrics
  - Computes incremental difference
  - Uses `$inc` to accumulate totals safely
  - Handles Prometheus counter resets gracefully

### Why this is needed
Previously, `eventsProcessed` was being aggregated directly, which resulted in the total counter increasing indefinitely. Additionally, the total was lost when the server restarted. This PR resolves both issues and provides accurate, persistent monitoring data.

### Testing Performed
- Confirmed counter increases only when new events arrive.
- Confirmed counter remains correct after server restart.
- Confirmed no duplicate increments occur.

### Next Steps
- Optional: expose `/metrics/history` for chart visualization.
- Optional: add dashboard UI.

