### PR TITLE
feat: add stations endpoints documentation and usage examples

### DIFF
--- a/frontend/src/data/StationsEndpointsData.json
+++ b/frontend/src/data/StationsEndpointsData.json
@@ -10,5 +10,16 @@
       { "name": "limit", "label": "limit", "placeholder": "50", "defaultValue": "50" },
       { "name": "page", "label": "page", "placeholder": "1", "defaultValue": "1" }
     ]
+  },
+  {
+    "key": "code",
+    "label": "code station",
+    "method": "GET",
+    "path": "/v1/stations/code",
+    "subtitle": "By code station",
+    "description": "This endpoint retrieves detailed information for a specific seismic monitoring station, identified by its unique station code.\n\nIt returns station metadata such as network, site name, geographic coordinates, elevation, and operational period.\n\nQuery Parameters:\n- code: (Required) The station code to search for (case-insensitive).",
+    "params": [
+      { "name": "code", "label": "code", "placeholder": "acate", "required": true }
+    ]
   }
 ]

--- a/frontend/src/pages/apiAccess/ApiAccess.jsx
+++ b/frontend/src/pages/apiAccess/ApiAccess.jsx
@@ -5,14 +5,13 @@ import { API_BASE } from '@/data/BaseApi';
 import { CopyButton } from '@components/utils/CopyButton';
 
 export default function ApiAccess() {
-
   const urlEndpoint = {
-    "earthquakes": "https://api.terraquakeapi.com/v1/earthquakes",
-    "stations": "https://api.terraquakeapi.com/v1/stations",
-  }
+    earthquakes: `${API_BASE}/v1/earthquakes`,
+    stations: `${API_BASE}/v1/stations`,
+  };
 
   const quickStart = {
-    "earthquakesJavascript": `
+    earthquakesJavascript: `
 // Fetch the 10 most recent earthquakes of the current year
 
 const fetchRecentEarthquakes = async (limit = 10) => {
@@ -51,12 +50,12 @@ const fetchRecentEarthquakes = async (limit = 10) => {
 
 fetchRecentEarthquakes(10);
       `,
-    "earthquakesPython": `
+    earthquakesPython: `
 # Fetch the 10 most recent earthquakes of the current year
 
 import requests
 
-url = "http://localhost:5001/v1/earthquakes/recent"
+url = \"${API_BASE}/v1/earthquakes/recent"
 params = {"limit": 10}
 
 response = requests.get(url, params=params)
@@ -77,8 +76,52 @@ if response.status_code == 200:
         print("Unexpected data format or no payload.")
 else:
   print(f"Error: {response.status_code} - {response.text}")
-      `
-  }
+      `,
+    stationsJavascript: `
+// Fetch the first 20 seismic monitoring stations
+
+const url = \'${API_BASE}/v1/stations';
+const params = new URLSearchParams({ page: 1, limit: 20 });
+
+fetch(\`\${url}?\${params.toString()}\`)
+  .then((response) => response.json())
+  .then((data) => {
+    if (data.success) {
+      console.log('Seismic Stations:', data.payload);
+      console.log(\`Total stations: \${data.totalStations}\`);
+    } else {
+      console.warn('No station data available.');
+    }
+  })
+  .catch((error) => console.error('API Error:', error));`,
+    stationsPython: `
+# Fetch the first 20 seismic monitoring stations
+
+import requests
+
+url = \"${API_BASE}/v1/stations"
+params = {
+    "page": 1,
+    "limit": 20
+}
+
+response = requests.get(url, params=params)
+
+if response.status_code == 200:
+    data = response.json()
+
+    if data.get("success") and "payload" in data:
+        print(f"Total stations: {data.get('totalStations', 'N/A')}")
+        for station in data["payload"]:
+            code = station.get("$", {}).get("code", "Unknown")
+            latitude = station.get("Latitude", "N/A")
+            longitude = station.get("Longitude", "N/A")
+            print(f"{code}: {latitude}, {longitude}")
+    else:
+        print("No station data found.")
+else:
+    print(f"Request failed: {response.status_code}")`,
+  };
 
   return (
     <>
@@ -162,7 +205,92 @@ else:
             </pre>
           </div>
 
-          {/* Query Parameters */}
+          {/* Endpoint Earthquakes List / Table */}
+          <div className='mb-14'>
+            <h2 className='text-2xl font-bold text-white mb-4'>
+              API Endpoints Earthquakes
+            </h2>
+            <p className='text-white/70 mb-4'>
+              All endpoints support pagination using <code>page</code> and{' '}
+              <code>limit</code>.
+            </p>
+
+            <div className='overflow-x-auto'>
+              <table className='w-full text-left text-white/80 text-sm border border-white/10 rounded-xl overflow-hidden'>
+                <thead className='bg-white/10 text-white'>
+                  <tr>
+                    <th className='px-4 py-3'>Method</th>
+                    <th className='px-4 py-3'>Endpoint</th>
+                    <th className='px-4 py-3'>Description</th>
+                    <th className='px-4 py-3'>Query Parameters</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td className='px-4 py-3'>GET</td>
+                    <td>/v1/earthquakes/recent</td>
+                    <td>Recent earthquakes from the start of the year.</td>
+                    <td>page, limit</td>
+                  </tr>
+                  <tr>
+                    <td className='px-4 py-3'>GET</td>
+                    <td>/v1/earthquakes/today</td>
+                    <td>Earthquakes recorded today.</td>
+                    <td>page, limit</td>
+                  </tr>
+                  <tr>
+                    <td className='px-4 py-3'>GET</td>
+                    <td>/v1/earthquakes/last-week</td>
+                    <td>Earthquakes in the past 7 days.</td>
+                    <td>page, limit</td>
+                  </tr>
+                  <tr>
+                    <td className='px-4 py-3'>GET</td>
+                    <td>/v1/earthquakes/month</td>
+                    <td>Earthquakes for a specific month/year.</td>
+                    <td>year* (required), month* (required), page, limit</td>
+                  </tr>
+                  <tr>
+                    <td className='px-4 py-3'>GET</td>
+                    <td>/v1/earthquakes/location</td>
+                    <td>Earthquakes near latitude/longitude.</td>
+                    <td>
+                      latitude* (required), longitude* (required), radius, page,
+                      limit
+                    </td>
+                  </tr>
+                  <tr>
+                    <td className='px-4 py-3'>GET</td>
+                    <td>/v1/earthquakes/region</td>
+                    <td>Earthquakes in an Italian region.</td>
+                    <td>region* (required), page, limit</td>
+                  </tr>
+                  <tr>
+                    <td className='px-4 py-3'>GET</td>
+                    <td>/v1/earthquakes/depth</td>
+                    <td>Earthquakes deeper than a given depth.</td>
+                    <td>depth* (required), page, limit</td>
+                  </tr>
+                  <tr>
+                    <td className='px-4 py-3'>GET</td>
+                    <td>/v1/earthquakes/range-time</td>
+                    <td>Earthquakes within a date range.</td>
+                    <td>
+                      startdate* (required), enddate* (required), page, limit
+                    </td>
+                  </tr>
+                  <tr>
+                    <td className='px-4 py-3'>GET</td>
+                    <td>/v1/earthquakes/eventId</td>
+                    <td>Get a single earthquake by ID.</td>
+                    <td>eventId* (required)</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          {/* Query Parameters Earthquakes */}
           <div className='mb-14'>
             <h2 className='text-2xl font-bold text-white mb-4'>
               Query Parameters Earthquakes
@@ -278,13 +406,38 @@ else:
             </div>
           </div>
 
-          {/* Endpoint List / Table */}
+          {/* Quick Examples Earthquakes */}
           <div className='mb-14'>
             <h2 className='text-2xl font-bold text-white mb-4'>
-              1) API Endpoints Earthquakes
+              Quick Start Examples for earthquakes
+            </h2>
+
+            <h4 className='flex justify-between text-lg font-semibold text-white mb-2'>
+              <p>JavaScript</p>
+              <p>Fetch the 10 most recent earthquakes of the current year</p>
+              <CopyButton text={quickStart.earthquakesJavascript} />
+            </h4>
+            <pre className='bg-black/30 border border-white/10 rounded-xl p-16 text-amber-300 text-sm overflow-x-auto'>
+              <code>{quickStart.earthquakesJavascript}</code>
+            </pre>
+
+            <h4 className='flex justify-between mt-6 text-lg font-semibold text-white mb-2'>
+              <p>Python</p>
+              <p>Fetch the 10 most recent earthquakes of the current year</p>
+              <CopyButton text={quickStart.earthquakesPython} />
+            </h4>
+            <pre className='bg-black/30 border border-white/10 rounded-xl p-16 text-green-700 text-sm overflow-x-auto'>
+              <code>{quickStart.earthquakesPython}</code>
+            </pre>
+          </div>
+
+          {/* Endpoint Stations List / Table */}
+          <div className='mb-14'>
+            <h2 className='text-2xl font-bold text-white mb-4'>
+              API Endpoints stations
             </h2>
             <p className='text-white/70 mb-4'>
-              All endpoints support pagination using <code>page</code> and{' '}
+              Some endpoints support pagination using <code>page</code> and{' '}
               <code>limit</code>.
             </p>
 
@@ -301,87 +454,117 @@ else:
                 <tbody>
                   <tr>
                     <td className='px-4 py-3'>GET</td>
-                    <td>/v1/earthquakes/recent</td>
-                    <td>Recent earthquakes from the start of the year.</td>
+                    <td>/v1/stations</td>
+                    <td>
+                      Retrieve all seismic monitoring stations (INGV network).
+                    </td>
                     <td>page, limit</td>
                   </tr>
                   <tr>
                     <td className='px-4 py-3'>GET</td>
-                    <td>/v1/earthquakes/today</td>
-                    <td>Earthquakes recorded today.</td>
+                    <td>/v1/stations/code</td>
+                    <td>Retrieve a station by its station code.</td>
+                    <td>code* (required)</td>
+                  </tr>
+                  <tr>
+                    <td className='px-4 py-3'>GET</td>
+                    <td>/v1/stations/geojson</td>
+                    <td>
+                      Retrieve all stations formatted as GeoJSON for mapping
+                      tools.
+                    </td>
                     <td>page, limit</td>
                   </tr>
                   <tr>
                     <td className='px-4 py-3'>GET</td>
-                    <td>/v1/earthquakes/last-week</td>
-                    <td>Earthquakes in the past 7 days.</td>
+                    <td>/v1/stations/status/open</td>
+                    <td>List all currently active/operational stations.</td>
                     <td>page, limit</td>
                   </tr>
                   <tr>
                     <td className='px-4 py-3'>GET</td>
-                    <td>/v1/earthquakes/month</td>
-                    <td>Earthquakes for a specific month/year.</td>
-                    <td>year*, month*, page, limit</td>
+                    <td>/v1/stations/status/closed</td>
+                    <td>List stations that are no longer operational.</td>
+                    <td>page, limit</td>
                   </tr>
                   <tr>
                     <td className='px-4 py-3'>GET</td>
-                    <td>/v1/earthquakes/location</td>
-                    <td>Earthquakes near latitude/longitude.</td>
-                    <td>latitude*, longitude*, radius, page, limit</td>
-                  </tr>
-                  <tr>
-                    <td className='px-4 py-3'>GET</td>
-                    <td>/v1/earthquakes/region</td>
-                    <td>Earthquakes in an Italian region.</td>
-                    <td>region*, page, limit</td>
-                  </tr>
-                  <tr>
-                    <td className='px-4 py-3'>GET</td>
-                    <td>/v1/earthquakes/depth</td>
-                    <td>Earthquakes deeper than a given depth.</td>
-                    <td>depth*, page, limit</td>
-                  </tr>
-                  <tr>
-                    <td className='px-4 py-3'>GET</td>
-                    <td>/v1/earthquakes/range-time</td>
-                    <td>Earthquakes within a date range.</td>
-                    <td>startdate*, enddate*, page, limit</td>
-                  </tr>
-                  <tr>
-                    <td className='px-4 py-3'>GET</td>
-                    <td>/v1/earthquakes/eventId</td>
-                    <td>Get a single earthquake by ID.</td>
-                    <td>eventId*</td>
+                    <td>/v1/stations/statistics</td>
+                    <td>
+                      Provides aggregated information about the station network.
+                    </td>
+                    <td>no parameters</td>
                   </tr>
                 </tbody>
               </table>
             </div>
           </div>
 
-          {/* Quick Examples */}
+          {/* Query Parameters Stations */}
           <div className='mb-14'>
             <h2 className='text-2xl font-bold text-white mb-4'>
-              1a) Quick Start Examples
+              Query Parameters Stations
+            </h2>
+            <p className='text-white/70 mb-4'>
+              These parameters are commonly used across station endpoints for
+              pagination and filtering:
+            </p>
+            <div className='overflow-x-auto'>
+              <table className='w-full text-left text-white/80 text-sm border border-white/10 rounded-xl overflow-hidden'>
+                <thead className='bg-white/10 text-white'>
+                  <tr>
+                    <th className='px-4 py-3'>Parameter</th>
+                    <th className='px-4 py-3'>Type</th>
+                    <th className='px-4 py-3'>Description</th>
+                    <th className='px-4 py-3'>Example</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td className='px-4 py-3'>page</td>
+                    <td>integer</td>
+                    <td>Page number for paginated results (default 1)</td>
+                    <td>?page=2</td>
+                  </tr>
+                  <tr>
+                    <td className='px-4 py-3'>limit</td>
+                    <td>integer</td>
+                    <td>Number of results per page (default 50)</td>
+                    <td>?limit=100</td>
+                  </tr>
+                  <tr>
+                    <td className='px-4 py-3'>code</td>
+                    <td>string</td>
+                    <td>Filters results to a specific station code.</td>
+                    <td>?code=acate</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          {/* Quick Examples Stations */}
+          <div className='mb-14'>
+            <h2 className='text-2xl font-bold text-white mb-4'>
+              Quick Start Examples for stations
             </h2>
 
-            <h4 className='text-lg font-semibold text-white mb-2'>
-              JavaScript
-              <CopyButton text={quickStart.earthquakesJavascript} />
+            <h4 className='flex justify-between text-lg font-semibold text-white mb-2'>
+              <p>JavaScript</p>
+              <p>Fetch the first 20 seismic monitoring stations</p>
+              <CopyButton text={quickStart.stationsJavascript} />
             </h4>
-            <pre className='bg-black/30 border border-white/10 rounded-xl p-16 text-white/90 text-sm overflow-x-auto'>
-              <code>
-                {quickStart.earthquakesJavascript}
-              </code>
+            <pre className='bg-black/30 border border-white/10 rounded-xl p-16 text-amber-300 text-sm overflow-x-auto'>
+              <code>{quickStart.stationsJavascript}</code>
             </pre>
 
-            <h4 className='mt-6 text-lg font-semibold text-white mb-2'>
-              Python
-              <CopyButton text={quickStart.earthquakesPython} />
+            <h4 className='flex justify-between mt-6 text-lg font-semibold text-white mb-2'>
+              <p>Python</p>
+              <p>Fetch the first 20 seismic monitoring stations</p>
+              <CopyButton text={quickStart.stationsPython} />
             </h4>
-            <pre className='bg-black/30 border border-white/10 rounded-xl p-16 text-white/90 text-sm overflow-x-auto'>
-              <code>
-                {quickStart.earthquakesPython}
-              </code>
+            <pre className='bg-black/30 border border-white/10 rounded-xl p-16 text-green-700 text-sm overflow-x-auto'>
+              <code>{quickStart.stationsPython}</code>
             </pre>
           </div>
 


### PR DESCRIPTION
### Summary

This PR adds full documentation and usage examples for the Seismic Monitoring Stations endpoints in the API Access section. The goal is to provide developers with clear and practical examples for requesting station data from the TerraQuake API.

### Changes Included
- Added `/v1/stations` endpoint documentation with description and parameter guidelines.
- Added example requests in both JavaScript (fetch) and Python (requests).
- Updated endpoint table to reflect station-related routes clearly.
- Improved parameter reference section for pagination and filtering.
- Prepared documentation to ensure consistency with newly added `/v1/stations/code` lookup endpoint.

### Why This Is Needed
Developers require simple and direct examples of how to interact with the Stations API.  
This update improves onboarding, reduces guesswork, and ensures all endpoints have consistent documentation.

### Testing
- Verified examples return structured JSON responses locally.
- Confirmed pagination parameters behave as expected.

---

Ready for review ✅
