### PR TITLE
feat: scaffold station controllers (geojson, status open/closed, stat…

### DIFF
--- a/backend/src/controllers/seimiscStationsControllers.js
+++ b/backend/src/controllers/seimiscStationsControllers.js
@@ -138,3 +138,148 @@ export const getCodeStation = ({ buildResponse, handleHttpError }) => {
     }
   }
 }
+
+/**
+ * NOTE: Controller: Get a seismic monitoring station.
+ *
+ * @route GET /stations/geojson
+ *
+ * @description
+ *  Returns the complete list of seismic monitoring stations formatted as GeoJSON.
+ *  Useful for mapping, visualization layers, and GIS applications.
+ *  Each feature includes station coordinates, elevation, name, and metadata.
+ */
+
+export const getStationsGeoJson = ({ buildResponse, handleHttpError }) => {
+  return async (req, res) => {
+    try {
+      const message = 'stations geojson'
+
+      res.status(200).json({
+        ...buildResponse(req, message, []),
+        totalStations: 0,
+        pagination: {
+          page: 0,
+          totalPages: 0,
+          limit: 0,
+          hasMore: false
+        }
+      })
+    } catch (error) {
+      console.error('Error retrieving stations:', error.message)
+      handleHttpError(
+        res,
+        error.message.includes('HTTP error') ? error.message : undefined
+      )
+    }
+  }
+}
+
+/**
+ * NOTE: Controller: Get a seismic monitoring station.
+ *
+ * @route GET /stations/status/open
+ *
+ * @description
+ *  Retrieves only the stations that are currently operational (open status).
+ *  These are stations actively collecting and transmitting seismic data.
+ */
+
+export const getStationsStatusOpen = ({ buildResponse, handleHttpError }) => {
+  return async (req, res) => {
+    try {
+      const message = 'get status open'
+
+      res.status(200).json({
+        ...buildResponse(req, message, []),
+        totalStations: 0,
+        pagination: {
+          page: 0,
+          totalPages: 0,
+          limit: 0,
+          hasMore: false
+        }
+      })
+    } catch (error) {
+      console.error('Error retrieving stations:', error.message)
+      handleHttpError(
+        res,
+        error.message.includes('HTTP error') ? error.message : undefined
+      )
+    }
+  }
+}
+
+/**
+ * NOTE: Controller: Get a seismic monitoring station.
+ *
+ * @route GET /stations/status/closed
+ *
+ * @description
+ *  Returns the list of stations that are no longer active.
+ *  Useful for historical analysis and network evolution studies.
+*/
+
+export const getStationsStatusClosed = ({ buildResponse, handleHttpError }) => {
+  return async (req, res) => {
+    try {
+      const message = 'get status closed'
+
+      res.status(200).json({
+        ...buildResponse(req, message, []),
+        totalStations: 0,
+        pagination: {
+          page: 0,
+          totalPages: 0,
+          limit: 0,
+          hasMore: false
+        }
+      })
+    } catch (error) {
+      console.error('Error retrieving stations:', error.message)
+      handleHttpError(
+        res,
+        error.message.includes('HTTP error') ? error.message : undefined
+      )
+    }
+  }
+}
+
+/**
+ * NOTE: Controller: Get a seismic monitoring station.
+ *
+ * @route GET /stations/statistics
+ *
+ * @description
+ *  Provides aggregate metrics such as:
+ *   - Total stations
+ *   - Number of active stations
+ *   - Number of closed stations
+ *   - Stations grouped by network or region
+ *  Useful for dashboards and monitoring network scale.
+ */
+
+export const getStationsStatistics = ({ buildResponse, handleHttpError }) => {
+  return async (req, res) => {
+    try {
+      const message = 'get statistics'
+
+      res.status(200).json({
+        ...buildResponse(req, message, []),
+        totalStations: 0,
+        pagination: {
+          page: 0,
+          totalPages: 0,
+          limit: 0,
+          hasMore: false
+        }
+      })
+    } catch (error) {
+      console.error('Error retrieving stations:', error.message)
+      handleHttpError(
+        res,
+        error.message.includes('HTTP error') ? error.message : undefined
+      )
+    }
+  }
+}

--- a/backend/src/routes/stationsRoutes.js
+++ b/backend/src/routes/stationsRoutes.js
@@ -1,5 +1,5 @@
 import express from 'express'
-import { getAllStations, getCodeStation } from '../controllers/seimiscStationsControllers.js'
+import { getAllStations, getCodeStation, getStationsGeoJson, getStationsStatistics, getStationsStatusClosed, getStationsStatusOpen } from '../controllers/seimiscStationsControllers.js'
 import { buildResponse } from '../utils/buildResponse.js'
 import handleHttpError from '../utils/handleHttpError.js'
 
@@ -17,18 +17,18 @@ router.get('/code', getCodeStation({ buildResponse, handleHttpError }))
 
 // NOTE: Returns all seismic stations in GeoJSON format (for mapping purposes)
 // GET /geojson — provides GeoJSON data of all seismic stations
-router.get('/geojson')
+router.get('/geojson', getStationsGeoJson({ buildResponse, handleHttpError }))
 
 // NOTE: Lists active stations
 // GET /status/open — retrieves a list of seismic stations that are currently active
-router.get('/status/open')
+router.get('/status/open', getStationsStatusOpen({ buildResponse, handleHttpError }))
 
 // NOTE: Lists closed stations
 // GET /status/closed — retrieves a list of seismic stations that are currently closed
-router.get('/status/closed')
+router.get('/status/closed', getStationsStatusClosed({ buildResponse, handleHttpError }))
 
 // NOTE: Statistics about seismic stations (e.g., total, active, by network)
 // GET /statistics — provides statistical summaries for seismic stations
-router.get('/statistics')
+router.get('/statistics', getStationsStatistics({ buildResponse, handleHttpError }))
 
 export default router


### PR DESCRIPTION
### Summary

This PR introduces the initial implementation of the Stations API controllers.  
The goal is to establish the structural foundation for the stations-related endpoints, which will later be connected to the real INGV station dataset and processing utilities.

### Endpoints Added

| Method | Endpoint                    | Description |
|--------|-----------------------------|-------------|
| GET    | /v1/stations/geojson        | Returns all seismic stations formatted as GeoJSON (for mapping + GIS use cases) |
| GET    | /v1/stations/status/open    | Lists all stations currently active (operational) |
| GET    | /v1/stations/status/closed  | Lists all stations marked as inactive or closed |
| GET    | /v1/stations/statistics     | Provides network-level statistics (total, active, closed, grouped data, etc.) |

### Current State

- All controllers currently return structured placeholder responses using `buildResponse`.
- Pagination and metadata formatting is already aligned with existing API response conventions.
- Logic for fetching and filtering station data will be implemented in the next phase.

### Next Steps (Upcoming Work)

- Integrate with `fetchINGVStations` to retrieve live station data.
- Implement filtering for operational status.
- Generate GeoJSON features dynamically.
- Add unit tests for the controllers.
