### PR TITLE
feat(stations): add controller and API route for closed seismic stations

### DIFF
--- a/frontend/src/data/StationsEndpointsData.json
+++ b/frontend/src/data/StationsEndpointsData.json
@@ -80,5 +80,27 @@
         "defaultValue": "1"
       }
     ]
+  },
+  {
+    "key": "closed",
+    "label": "Status: Closed",
+    "method": "GET",
+    "path": "/v1/stations/status/closed",
+    "subtitle": "List of inactive or decommissioned seismic stations",
+    "description": "This endpoint returns seismic monitoring stations that are currently not operational (closed/restricted).\n\nIt provides metadata such as network code, station name, location coordinates, elevation, and deactivation details.\n\nUseful for historical research, network maintenance planning, infrastructure audits, and understanding changes in seismic network coverage.\n\nSupports optional pagination with `limit` and `page`.",
+    "params": [
+      {
+        "name": "limit",
+        "label": "limit",
+        "placeholder": "50",
+        "defaultValue": "50"
+      },
+      {
+        "name": "page",
+        "label": "page",
+        "placeholder": "1",
+        "defaultValue": "1"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
### Overview
This PR introduces support for retrieving seismic stations that are currently inactive or restricted (status: closed). This complements the existing `/v1/stations/status/open` endpoint and improves network transparency for research and system monitoring.

### Key Changes
- Added new controller method to fetch closed stations.
- Created route: `GET /v1/stations/status/closed`
- Implemented pagination support (`limit` and `page`).
- Added new explorer dataset entry for closed stations.
- Updated the frontend explorer configuration with the label, path, description, and parameters.

### Why This Matters
This endpoint allows users to:
- Analyze the evolution of the seismic network
- Audit decommissioned / temporarily disabled stations
- Support historical data comparisons and maintenance planning

### Testing
- Verified route returns correct station sets
- Confirmed pagination behavior matches open station endpoint
- Confirmed no regressions to existing `/open` controller

