### PR TITLE
feat(stations): add statistics endpoint with total, open and closed c…

### DIFF
--- a/frontend/src/data/EarthquakesEndpointsData.json
+++ b/frontend/src/data/EarthquakesEndpointsData.json
@@ -1,7 +1,7 @@
 [
   {
     "key": "recent",
-    "label": "recent",
+    "label": "Recent",
     "method": "GET",
     "path": "/v1/earthquakes/recent",
     "subtitle": "Latest sismic events",
@@ -13,7 +13,7 @@
   },
   {
     "key": "today",
-    "label": "today",
+    "label": "Today",
     "method": "GET",
     "path": "/v1/earthquakes/today",
     "subtitle": "Today seismic events",
@@ -25,7 +25,7 @@
   },
   {
     "key": "last-week",
-    "label": "last-week",
+    "label": "Last-Week",
     "method": "GET",
     "path": "/v1/earthquakes/last-week",
     "subtitle": "Last 7 days",
@@ -37,7 +37,7 @@
   },
   {
     "key": "month",
-    "label": "month",
+    "label": "Month",
     "method": "GET",
     "path": "/v1/earthquakes/month",
     "subtitle": "By month/year",
@@ -51,7 +51,7 @@
   },
   {
     "key": "location",
-    "label": "location",
+    "label": "Location",
     "method": "GET",
     "path": "/v1/earthquakes/location",
     "subtitle": "Near latitude/longitude",
@@ -66,7 +66,7 @@
   },
   {
     "key": "region",
-    "label": "region",
+    "label": "Region",
     "method": "GET",
     "path": "/v1/earthquakes/region",
     "subtitle": "By Italian region",
@@ -79,7 +79,7 @@
   },
   {
     "key": "depth",
-    "label": "depth",
+    "label": "Depth",
     "method": "GET",
     "path": "/v1/earthquakes/depth",
     "subtitle": "By focal depth (km)",
@@ -92,7 +92,7 @@
   },
   {
     "key": "range-time",
-    "label": "range-time",
+    "label": "Range-Time",
     "method": "GET",
     "path": "/v1/earthquakes/range-time",
     "subtitle": "By time range",
@@ -106,7 +106,7 @@
   },
   {
     "key": "magnitude",
-    "label": "magnitude",
+    "label": "Magnitude",
     "method": "GET",
     "path": "/v1/earthquakes/magnitude",
     "subtitle": "Min magnitude",
@@ -119,7 +119,7 @@
   },
   {
     "key": "eventId",
-    "label": "eventId",
+    "label": "Event Id",
     "method": "GET",
     "path": "/v1/earthquakes/eventId",
     "subtitle": "By event ID",

--- a/frontend/src/data/StationsEndpointsData.json
+++ b/frontend/src/data/StationsEndpointsData.json
@@ -1,7 +1,7 @@
 [
   {
     "key": "stations",
-    "label": "stations",
+    "label": "Stations",
     "method": "GET",
     "path": "/v1/stations",
     "subtitle": "List stations seismic INGV",
@@ -23,7 +23,7 @@
   },
   {
     "key": "code",
-    "label": "code station",
+    "label": "Code Station",
     "method": "GET",
     "path": "/v1/stations/code",
     "subtitle": "By code station",
@@ -102,5 +102,14 @@
         "defaultValue": "1"
       }
     ]
+  },
+  {
+    "key": "statistics",
+    "label": "Network Statistics",
+    "method": "GET",
+    "path": "/v1/stations/statistics",
+    "subtitle": "Seismic network summary",
+    "description": "This endpoint provides a summary of the seismic monitoring network, returning the total number of stations along with how many are currently operational (open) and how many are inactive or restricted (closed).\n\nUseful for dashboards, network health monitoring, performance analytics, transparency reporting, and historical comparisons of network size and operational status.",
+    "params": []
   }
 ]


### PR DESCRIPTION
### Summary
This PR introduces the `/v1/stations/statistics` endpoint, which provides a network-level
summary of seismic stations. The response includes:
- Total number of stations
- Number of open (active) stations
- Number of closed/restricted (inactive) stations

### Why
This endpoint is useful for:
- Network monitoring dashboards
- Infrastructure and operational auditing
- Historical comparisons of station availability
- High-level analytics and reporting

### Changes
- Added controller logic in `controllers/stations.controller.js`
- Added route to `routes/stations.routes.js`
- Updated API Explorer documentation with revised description and metadata

### Testing
- Verified response values against known dataset
- Verified pagination and filtering do not apply to this endpoint
- Manually inspected output in API Explorer
