### PR TITLE
feat: enforce user role as 'user' in signUp and update user model to …

### DIFF
--- a/backend/src/controllers/authControllers.js
+++ b/backend/src/controllers/authControllers.js
@@ -19,6 +19,9 @@ export const signUp = ({
       // Extract validated data from request
       const data = matchedData(req)
 
+      // Force Role — Never trust client
+      data.role = 'user'
+
       // Check if a user already exists, including soft-deleted ones
       const existingUser = await User.findOneWithDeleted({ email: data.email })
 
@@ -29,7 +32,7 @@ export const signUp = ({
           existingUser.deletedAt = null
           existingUser.name = data.name
           existingUser.password = data.password // hashed in pre-save hook
-          existingUser.role = data.role || 'user'
+          existingUser.role = 'user'
           existingUser.experience = data.experience || ''
           existingUser.student = data.student || 'No'
           existingUser.bio = data.bio || ''
@@ -70,6 +73,7 @@ export const signUp = ({
       }
 
       // Create a new user
+      data.role = 'user'
       const newUser = new User(data)
       const savedUser = await newUser.save()
       const user = savedUser.toObject()

--- a/backend/src/models/userModels.js
+++ b/backend/src/models/userModels.js
@@ -38,7 +38,7 @@ const usersSchema = new Schema(
     },
     role: {
       type: String,
-      enum: ['user', 'admin', 'contributor'],
+      enum: ['user', 'admin'],
       default: 'user'
     },
     experience: {


### PR DESCRIPTION
### Description
This PR fixes a critical security issue that allowed clients to self-assign privileged roles during user registration.

**Problem**
The signUp controller trusted client-provided input, allowing a malicious user to register as admin by sending "role": "admin" via tools such as Postman.

**Solution**
Enforced role = "user" server-side during signup, regardless of client input
Updated the User model to restrict allowed roles and define a secure default
Ensured restored (soft-deleted) users are always reactivated with the user role
This change fully prevents privilege escalation during public registration.

